### PR TITLE
Archive version 0.0.1

### DIFF
--- a/docs/versions/v0.0.1/index.html
+++ b/docs/versions/v0.0.1/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>vc-http-api</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
+        <script>
+            window.onload = function () {
+                // Begin Swagger UI call region
+                const ui = SwaggerUIBundle({
+                    url: "vc-http-api.yml",
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>

--- a/docs/versions/v0.0.1/vc-http-api.yml
+++ b/docs/versions/v0.0.1/vc-http-api.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "0.0.2-unstable"
+  version: "0.0.0"
   title: VC HTTP API
   description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
   license:


### PR DESCRIPTION
This moves the "latest" version to the archive, and opens the door for breaking changes in "v0.0.2-unstable"

No changes have been made at this time to "v0.0.2-unstable"