### PR TITLE
OAuth2.0 Client Credentials Request Authorization Support

### DIFF
--- a/packages/plugfest-2020/.gitignore
+++ b/packages/plugfest-2020/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/plugfest-2020/help.js
+++ b/packages/plugfest-2020/help.js
@@ -1,10 +1,16 @@
 const fetch = require('node-fetch');
 
-const getJson = async url => {
+const getJson = async (url, requestAuthorization) => {
+  let headers = {
+    Accept: 'application/ld+json',
+  };
+
+  if (requestAuthorization && requestAuthorization.type === "oauth2-bearer-token") {
+    headers.Authorization = `Bearer ${requestAuthorization.accessToken}`
+  }
+
   const res = await fetch(url, {
-    headers: {
-      Accept: 'application/ld+json',
-    },
+    headers,
     method: 'get',
   });
 
@@ -16,21 +22,23 @@ const getJson = async url => {
   return res;
 };
 
-const postJson = async (url, body) => {
+const postJson = async (url, body, requestAuthorization) => {
+  let headers = {
+    Accept: 'application/ld+json,application/json',
+    'Content-Type': 'application/json',
+  };
+
+  if (requestAuthorization && requestAuthorization.type === "oauth2-bearer-token") {
+    headers.Authorization = `Bearer ${requestAuthorization.accessToken}`
+  }
+
   const res = await fetch(url, {
-    headers: {
-      Accept: 'application/ld+json,application/json',
-      'Content-Type': 'application/json',
-    },
+    headers,
     method: 'post',
     body: JSON.stringify(body),
   });
   const resBody = await res.json();
-  // if (res.status > 300) {
-  //   console.error("ERROR with POST: ", url);
-  //   console.error("BODY: ", JSON.stringify(body, null, 2));
-  //   console.error(resBody);
-  // }
+
   return {status: res.status, body: resBody};
 };
 

--- a/packages/plugfest-2020/utilities/oauth.js
+++ b/packages/plugfest-2020/utilities/oauth.js
@@ -1,0 +1,22 @@
+const help = require("../help");
+
+/**
+ * Performs OAuth2.0 Client Credentials flow to obtain an access token
+ * @see https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
+ * @param options 
+ */
+module.exports.getAccessTokenViaClientCredentials = async ({
+    token_endpoint,
+    client_id,
+    client_secret,
+    audience
+}) => {
+    const result = await help.postJson(token_endpoint, {
+        client_id,
+        client_secret,
+        audience,
+        grant_type: "client_credentials"
+    });
+
+    return result.body.access_token;
+}


### PR DESCRIPTION
This PR adds basic support for obtaining an access_token for request authorization via the client credentials. Has been tested locally but our environment is not stood up yet so I have not checked in our vendor config that will use this feature. Ideally we need to support the injection of secrets for each vendors config via GH secrets rather than checking it into the repo directly.

To use this feature, add this config element to your vendor config

```
{
   ...,
  request_authorization_config: {
    type: "oauth2-client-credentials",
    token_endpoint: " https://idp.com/oauth/token",
    client_id: "xxxxxxxx",
    client_secret: "xxxxxxxxxx",
    audience: "optional-audience-constraint"
  }
}
```

Fixes #86