### PR TITLE
feat: add support for credentialStatus on credential issue

### DIFF
--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -171,7 +171,7 @@ components:
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
           "proofPurpose": "assertionMethod",
           "created": "2020-04-02T18:48:36Z",
-          "domain": "example.com",
+          "domain": "revocation.example",
           "challenge": "d436f0c8-fbd9-4e48-bbb2-55fc5d0920a8",
           "credentialStatusMethod": "RevocationList2020Status",
         }

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -162,7 +162,7 @@ components:
           description: A challenge provided by the requesting party of the proof.
         domain:
           type: string
-          description: The domain of the proof.
+          description: The intended domain of validity for the proof. For example: website.example
         credentialStatusMethod:
           type: string
           description: The method of credential status to issue the credential including. If omitted credential status will be included.

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -156,7 +156,7 @@ components:
           description: The purpose of the proof. Default: "assertionMethod".
         created:
           type: string
-          description: The date of the proof. If omitted system time will be used.
+          description: The date and time of the proof (with a maximum accuracy in seconds). Default: current system time.
         challenge:
           type: string
           description: The challenge of the proof.

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -153,7 +153,7 @@ components:
           description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
         proofPurpose:
           type: string
-          description: The purpose of the proof. If omitted "assertionMethod" will be used.
+          description: The purpose of the proof. Default: "assertionMethod".
         created:
           type: string
           description: The date of the proof. If omitted system time will be used.

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -153,19 +153,23 @@ components:
           description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
         proofPurpose:
           type: string
-          description: The purpose of the proof. Default: "assertionMethod".
+          description: The purpose of the proof. Default 'assertionMethod'.
         created:
           type: string
-          description: The date and time of the proof (with a maximum accuracy in seconds). Default: current system time.
+          description: The date and time of the proof (with a maximum accuracy in seconds). Default current system time.
         challenge:
           type: string
-          description: A challenge provided by the requesting party of the proof. For example: 6e62f66e-67de-11eb-b490-ef3eeefa55f2
+          description: A challenge provided by the requesting party of the proof. For example 6e62f66e-67de-11eb-b490-ef3eeefa55f2
         domain:
           type: string
-          description: The intended domain of validity for the proof. For example: website.example
-        credentialStatusMethod:
-          type: string
+          description: The intended domain of validity for the proof. For example website.example
+        credentialStatus:
+          type: object
           description: The method of credential status to issue the credential including. If omitted credential status will be included.
+          properties:
+            type:
+              type: string
+              description: The type of credential status to issue the credential with
       example:
         {
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
@@ -173,7 +177,9 @@ components:
           "created": "2020-04-02T18:48:36Z",
           "domain": "revocation.example",
           "challenge": "d436f0c8-fbd9-4e48-bbb2-55fc5d0920a8",
-          "credentialStatusMethod": "RevocationList2020Status",
+          "credentialStatus": {
+            "type": "RevocationList2020Status"
+          }
         }
     PresentCredentialOptions:
       type: object
@@ -182,19 +188,19 @@ components:
       properties:
         verificationMethod:
           type: string
-          description: The URI of the verificationMethod used for the proof. If omitted a default assertionMethod will be used.
+          description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
         proofPurpose:
           type: string
-          description: The purpose of the proof. If omitted "assertionMethod" will be used.
+          description: The purpose of the proof. Default 'assertionMethod'.
         created:
           type: string
-          description: The date of the proof. If omitted system time will be used.
+          description: The date and time of the proof (with a maximum accuracy in seconds). Default current system time.
         challenge:
           type: string
-          description: The challenge of the proof.
+          description: A challenge provided by the requesting party of the proof. For example 6e62f66e-67de-11eb-b490-ef3eeefa55f2
         domain:
           type: string
-          description: The domain of the proof.
+          description: The intended domain of validity for the proof. For example website.example
       example:
         {
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
@@ -210,19 +216,19 @@ components:
       properties:
         verificationMethod:
           type: string
-          description: The URI of the verificationMethod used for the proof. If omitted a default assertionMethod will be used.
+          description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
         proofPurpose:
           type: string
-          description: The purpose of the proof. If omitted "assertionMethod" will be used.
+          description: The purpose of the proof. Default 'assertionMethod'.
         created:
           type: string
-          description: The date of the proof. If omitted system time will be used.
+          description: The date and time of the proof (with a maximum accuracy in seconds). Default current system time.
         challenge:
           type: string
-          description: The challenge of the proof.
+          description: A challenge provided by the requesting party of the proof. For example 6e62f66e-67de-11eb-b490-ef3eeefa55f2
         domain:
           type: string
-          description: The domain of the proof.
+          description: The intended domain of validity for the proof. For example website.example
       example:
         {
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -159,7 +159,7 @@ components:
           description: The date and time of the proof (with a maximum accuracy in seconds). Default: current system time.
         challenge:
           type: string
-          description: A challenge provided by the requesting party of the proof.
+          description: A challenge provided by the requesting party of the proof. For example: 6e62f66e-67de-11eb-b490-ef3eeefa55f2
         domain:
           type: string
           description: The intended domain of validity for the proof. For example: website.example

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -143,7 +143,67 @@ components:
           "proofPurpose": "assertionMethod",
           "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
         }
-    LinkedDataProofOptions:
+    IssueCredentialOptions:
+      type: object
+      additionalProperties: false
+      description: Options for specifying how the LinkedDataProof is created.
+      properties:
+        verificationMethod:
+          type: string
+          description: The URI of the verificationMethod used for the proof. If omitted a default assertionMethod will be used.
+        proofPurpose:
+          type: string
+          description: The purpose of the proof. If omitted "assertionMethod" will be used.
+        created:
+          type: string
+          description: The date of the proof. If omitted system time will be used.
+        challenge:
+          type: string
+          description: The challenge of the proof.
+        domain:
+          type: string
+          description: The domain of the proof.
+        credentialStatusMethod:
+          type: string
+          description: The method of credential status to issue the credential including. If omitted credential status will be included.
+      example:
+        {
+          "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+          "proofPurpose": "assertionMethod",
+          "created": "2020-04-02T18:48:36Z",
+          "domain": "example.com",
+          "challenge": "d436f0c8-fbd9-4e48-bbb2-55fc5d0920a8",
+          "credentialStatusMethod": "RevocationList2020Status",
+        }
+    PresentCredentialOptions:
+      type: object
+      additionalProperties: false
+      description: Options for specifying how the LinkedDataProof is created.
+      properties:
+        verificationMethod:
+          type: string
+          description: The URI of the verificationMethod used for the proof. If omitted a default assertionMethod will be used.
+        proofPurpose:
+          type: string
+          description: The purpose of the proof. If omitted "assertionMethod" will be used.
+        created:
+          type: string
+          description: The date of the proof. If omitted system time will be used.
+        challenge:
+          type: string
+          description: The challenge of the proof.
+        domain:
+          type: string
+          description: The domain of the proof.
+      example:
+        {
+          "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+          "proofPurpose": "assertionMethod",
+          "created": "2020-04-02T18:48:36Z",
+          "domain": "example.com",
+          "challenge": "d436f0c8-fbd9-4e48-bbb2-55fc5d0920a8",
+        }
+    VerifyOptions:
       type: object
       additionalProperties: false
       description: Options for specifying how the LinkedDataProof is created.
@@ -179,12 +239,18 @@ components:
         checks:
           type: array
           description: The checks performed
+          items:
+            type: string
         warnings:
           type: array
           description: Warnings
+          items:
+            type: string
         errors:
           type: array
           description: Errors
+          items:
+            type: string
       example: { "checks": ["proof"], "warnings": [], "errors": [] }
     Issuer:
       type: object
@@ -204,12 +270,16 @@ components:
         "@context":
           type: array
           description: The JSON-LD context of the credential.
+          items:
+            type: string
         "id":
           type: string
           description: The ID of the credential.
         "type":
           type: array
           description: The JSON-LD type of the credential.
+          items:
+            type: string
         "issuer":
           $ref: "#/components/schemas/Issuer"
         "issuanceDate":
@@ -287,18 +357,24 @@ components:
         "@context":
           type: array
           description: The JSON-LD context of the presentation.
+          items:
+            type: string
         "id":
           type: string
           description: The ID of the presentation.
         "type":
           type: array
           description: The JSON-LD type of the presentation.
+          items:
+            type: string
         "holder":
           type: object
           description: The holder
         "verifiableCredential":
           type: array
           description: The Verifiable Credentials
+          items:
+            type: object        
       example:
         {
           "@context":
@@ -400,7 +476,7 @@ components:
         credential:
           $ref: "#/components/schemas/Credential"
         options:
-          $ref: "#/components/schemas/LinkedDataProofOptions"
+          $ref: "#/components/schemas/IssueCredentialOptions"
     IssueCredentialResponse:
       $ref: "#/components/schemas/VerifiableCredential"
     ProvePresentationRequest:
@@ -409,7 +485,7 @@ components:
         presentation:
           $ref: "#/components/schemas/Presentation"
         options:
-          $ref: "#/components/schemas/LinkedDataProofOptions"
+          $ref: "#/components/schemas/PresentCredentialOptions"
     ProvePresentationResponse:
       $ref: "#/components/schemas/VerifiablePresentation"
     VerifyCredentialRequest:
@@ -418,7 +494,7 @@ components:
         verifiableCredential:
           $ref: "#/components/schemas/VerifiableCredential"
         options:
-          $ref: "#/components/schemas/LinkedDataProofOptions"
+          $ref: "#/components/schemas/VerifyOptions"
     VerifyCredentialResponse:
       $ref: "#/components/schemas/VerificationResult"
     VerifyPresentationRequest:
@@ -427,6 +503,6 @@ components:
         verifiablePresentation:
           $ref: "#/components/schemas/VerifiablePresentation"
         options:
-          $ref: "#/components/schemas/LinkedDataProofOptions"
+          $ref: "#/components/schemas/VerifyOptions"
     VerifyPresentationResponse:
       $ref: "#/components/schemas/VerificationResult"

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -159,7 +159,7 @@ components:
           description: The date and time of the proof (with a maximum accuracy in seconds). Default: current system time.
         challenge:
           type: string
-          description: The challenge of the proof.
+          description: A challenge provided by the requesting party of the proof.
         domain:
           type: string
           description: The domain of the proof.

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -150,7 +150,7 @@ components:
       properties:
         verificationMethod:
           type: string
-          description: The URI of the verificationMethod used for the proof. If omitted a default assertionMethod will be used.
+          description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
         proofPurpose:
           type: string
           description: The purpose of the proof. If omitted "assertionMethod" will be used.


### PR DESCRIPTION
This PR proposes support for issuing a verifiable credential that includes a credential status, whereby one valid type of credential status implementation is [RevocationList2020](https://w3c-ccg.github.io/vc-status-rl-2020/).

The intended behaviour is that if the credentialStatusMethod property is present in the issue options section of the request, then the requestor is asking the issuer to issue a verifiable credential featuring a status using the method specified in the request.

Outstanding questions for review
- Are there options beyond just the credential status that should be communicated in the issuance request? E.g the initial state of the credentials status? Which revocation list (if applicable) the credential status should be issued against?
- How does a requestor know what credential status methods the issuer supports see [here](https://github.com/w3c-ccg/vc-http-api/issues/91) for an elaboration.

It is also of note, that this API currently assumes that the issuer co-ordinates much of the hidden detail required to issue the credential under a particular method, e.g for revocation list 2020 this could involve creating and hosting a new revocation list or allocating the issued credential against a previously created one.

Resolves #90