### PR TITLE
Add type property to LinkedDataProofOptions

### DIFF
--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -148,6 +148,9 @@ components:
       additionalProperties: false
       description: Options for specifying how the LinkedDataProof is created.
       properties:
+        type:
+          type: string
+          description: The type of the proof. If omitted a default proof type will be used.
         verificationMethod:
           type: string
           description: The URI of the verificationMethod used for the proof. If omitted a default assertionMethod will be used.


### PR DESCRIPTION
This enables callers to choose the proof type in case the server supports multiple proof types.