### PR TITLE
feat: add update credential status endpoint

### DIFF
--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -58,7 +58,7 @@ paths:
         "200":
           description: Credential status successfully updated!
         "400":
-          description: invalid input!
+          description: Malformed input.
         "404":
           description: credential not found!
         "500":

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -59,6 +59,8 @@ paths:
           description: Credential status successfully updated!
         "400":
           description: invalid input!
+        "404":
+          description: credential not found!
         "500":
           description: error!
   /presentations/prove:

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -56,13 +56,13 @@ paths:
         description: Parameters for updating the status of the issued credential.
       responses:
         "200":
-          description: Credential status successfully updated!
+          description: Credential status successfully updated
         "400":
-          description: Bad Request!
+          description: Bad Request
         "404":
-          description: Credential not found!
+          description: Credential not found
         "500":
-          description: Internal Server Error!
+          description: Internal Server Error
   /presentations/prove:
     post:
       tags:

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -62,7 +62,7 @@ paths:
         "404":
           description: credential not found!
         "500":
-          description: error!
+          description: Internal server error.
   /presentations/prove:
     post:
       tags:

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -158,13 +158,13 @@ components:
               type:
                 type: string
               status:
-                type: number
+                type: string
       example:
         { 
           "credentialId": "urn:uuid:45a44711-e457-4fa8-9b89-69fe0287c86a",
           "credentialStatus": [{
             "type": "RevocationList2020Status",
-            "status": 0
+            "status": "0"
           }]
         }
     LinkedDataProof:

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -41,6 +41,26 @@ paths:
           description: invalid input!
         "500":
           description: error!
+  /credentials/updateStatus:
+    post:
+      tags:
+        - Issuer
+      summary: Updates the status of an issued credential
+      operationId: updateCredentialStatus
+      description: Updates the status of an issued credential.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateCredentialStatus"
+        description: Parameters for updating the status of the issued credential.
+      responses:
+        "200":
+          description: Credential status successfully updated!
+        "400":
+          description: invalid input!
+        "500":
+          description: error!
   /presentations/prove:
     post:
       tags:
@@ -122,6 +142,24 @@ paths:
 
 components:
   schemas:
+    UpdateCredentialStatus:
+      type: object
+      description: Request for updating the status of an issued credential.
+      oneOf:
+        - type: object
+          properties:
+            credentialId:
+              type: string
+            type:
+              type: string
+            status:
+              type: number
+      example:
+        { 
+          "credentialId": "urn:uuid:45a44711-e457-4fa8-9b89-69fe0287c86a",
+          "type": "RevocationList2020Status",
+          "status": 0
+        }
     LinkedDataProof:
       type: object
       description: A JSON-LD Linked Data proof.

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -41,7 +41,7 @@ paths:
           description: invalid input!
         "500":
           description: error!
-  /credentials/updateStatus:
+  /credentials/status:
     post:
       tags:
         - Issuer
@@ -58,11 +58,11 @@ paths:
         "200":
           description: Credential status successfully updated!
         "400":
-          description: Malformed input.
+          description: Bad Request!
         "404":
-          description: credential not found!
+          description: Credential not found!
         "500":
-          description: Internal server error.
+          description: Internal Server Error!
   /presentations/prove:
     post:
       tags:
@@ -147,20 +147,25 @@ components:
     UpdateCredentialStatus:
       type: object
       description: Request for updating the status of an issued credential.
-      oneOf:
-        - type: object
-          properties:
-            credentialId:
-              type: string
-            type:
-              type: string
-            status:
-              type: number
+      properties:
+        credentialId:
+          type: string
+        credentialStatus:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              status:
+                type: number
       example:
         { 
           "credentialId": "urn:uuid:45a44711-e457-4fa8-9b89-69fe0287c86a",
-          "type": "RevocationList2020Status",
-          "status": 0
+          "credentialStatus": [{
+            "type": "RevocationList2020Status",
+            "status": 0
+          }]
         }
     LinkedDataProof:
       type: object


### PR DESCRIPTION
This PR adds a credential issuer API for managing an update to the status of an issued credential.

*Outstanding Questions*

- ~~How should the status property relate to the type property in the request? Are we assuming that the type sets the valid enumeration of values for status?~~ Yes
- ~~Is the credentialId the id of the issued credential?~~ Yes