### PR TITLE
Minor test suite improvements

### DIFF
--- a/packages/vc-http-api-test-server/services/jest/cli.js
+++ b/packages/vc-http-api-test-server/services/jest/cli.js
@@ -1,12 +1,15 @@
-const jestRunner = require("jest");
+const jest = require("jest");
 const path = require("path");
 
+const JEST_TEST_TIMEOUT_MS = 15000;
+
 module.exports = async (config) => {
-  let results = await jestRunner.runCLI(
+  let results = await jest.runCLI(
     {
       json: false,
       roots: [path.resolve(`${__dirname}/../../`)],
       globals: JSON.stringify({ suiteConfig: config }),
+      testTimeout: JEST_TEST_TIMEOUT_MS
     },
     [process.cwd()]
   );

--- a/packages/vc-http-api-test-server/services/jest/utilities.js
+++ b/packages/vc-http-api-test-server/services/jest/utilities.js
@@ -2,10 +2,10 @@ module.exports = extractTestSummary = (results) => {
   return {
     name: results.name,
     testResults: {
-      numFailedTests: results.testResults.results.numFailedTests,
-      numPassedTests: results.testResults.results.numPassedTests,
-      numTotalTests: results.testResults.results.numTotalTests,
-      testResults: results.testResults.results.testResults.map((result) => {
+      numFailedTests: results.numFailedTests,
+      numPassedTests: results.numPassedTests,
+      numTotalTests: results.numTotalTests,
+      testResults: results.testResults.map((result) => {
         return {
           numFailingTests: result.numFailingTests,
           numPassingTests: result.numPassingTests,


### PR DESCRIPTION
Set a default test timeout for jest of 15 secs as some did resolution requests that were using remote resolvers were taking sometime to resolve. Also fixed generating the JSON based report summary for the tests.