### PR TITLE
feat: add issue credential with revocation status tests

### DIFF
--- a/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js
+++ b/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js
@@ -109,7 +109,7 @@ if (suiteConfig.issueCredentialConfiguration) {
           expect(res.status).toBe(400);
         });
 
-        it(`9. The Issuer's Issue Credential HTTP API MUST must support no "options" in the body of the POST request.`, async () => {
+        it(`9. The Issuer's Issue Credential HTTP API MUST support no "options" in the body of the POST request.`, async () => {
           const body = {
             credential: {
               ...credentials[0].data,
@@ -120,6 +120,49 @@ if (suiteConfig.issueCredentialConfiguration) {
           expect(res.status).toBe(201);
           expect(res.body.proof).toBeDefined();
         });
+
+        if (value.credentialStatusesSupported) {
+          const credentialStatusesSupported = Array.isArray(value.credentialStatusesSupported) ? value.credentialStatusesSupported : [ value.credentialStatusesSupported ];
+
+          credentialStatusesSupported.forEach((credStatusType) => {
+            it(`10. The Issuer's Issue Credential HTTP API MAY support issuing a credential with a credential status type of ${credStatusType}`, async () => {
+              const body = {
+                credential: {
+                  ...credentials[0].data,
+                  issuer: value.id
+                },
+                options: {
+                  ...value.options[0],
+                  credentialStatus: {
+                    type: credStatusType
+                  },
+                },
+              };
+              const res = await httpClient.postJson(value.endpoint, body, {});
+              expect(res.status).toBe(201);
+              expect(res.body).toBeDefined();
+              expect(res.body.credentialStatus).toBeDefined();
+              expect(res.body.credentialStatus.type).toEqual(credStatusType);
+            });
+          });
+
+          it(`11. The Issuer's Issue Credential HTTP API MUST return 400 if credential status type not recognized`, async () => {
+            const body = {
+              credential: {
+                ...credentials[0].data,
+                issuer: value.id
+              },
+              options: {
+                ...value.options[0],
+                credentialStatus: {
+                  type: "BadType"
+                },
+              },
+            };
+            const res = await httpClient.postJson(value.endpoint, body, {});
+            expect(res.status).toBe(400);
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
~~PR is dependent on #110 #115 being merged ahead.~~

~~If you want to review before rebase, please just review [60cd0f5](https://github.com/w3c-ccg/vc-http-api/commit/60cd0f51c9b35fe5b58c12ac630ed97088499d5f).~~

The PR adds two new *optional* test cases to the VC HTTP Issuance API for issuing a credential with a credential status.

Has been test against our infrastructure but we have not exposed ours yet so no vendors in the current test suite are hitting these tests. A vendor can express support for optional feature by including the following in their `issueCredentialConfiguration` element

```
{
  credentialStatusesSupported: [ "RevocationList2020Status" ]
}
```