### PR TITLE
feat: add hostable revocation list as fixture

### DIFF
--- a/docs/fixtures/README.md
+++ b/docs/fixtures/README.md
@@ -1,0 +1,7 @@
+# Fixtures
+
+This folder contains static test fixtures that are hosted by this test suite.
+
+## revocationList.json
+
+Is a Verifiable Credential based revocation list conforming to the [RevocationStatusList2020](https://w3c-ccg.github.io/vc-status-rl-2020/) spec, whereby the credential associated to index 1 is revoked and all other credentials described by the other indexes represented in the list are not revoked.

--- a/docs/fixtures/revocationList.json
+++ b/docs/fixtures/revocationList.json
@@ -1,0 +1,26 @@
+{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/vc-revocation-list-2020/v1"
+    ],
+    "id": "https://w3c-ccg.github.io/vc-http-api/fixtures/revocationList.json",
+    "type": [
+      "VerifiableCredential",
+      "RevocationList2020Credential"
+    ],
+    "issuer": {
+      "id": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+    },
+    "issuanceDate": "2021-02-15T07:50:03.050Z",
+    "credentialSubject": {
+      "type": "RevocationList2020",
+      "encodedList": "H4sIAAAAAAAAA-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2021-02-15T07:50:03Z",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qN657PZcI21d3hZsjlHaINGMJ0URuP9Lo8-0vYqNrPK6WEOB1SsegmyFSwRMcvyrKpWfcorpBsDFLwdwcVHNBA",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3#z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+    }
+}


### PR DESCRIPTION
This PR is the first part of adding verify tests for revocation. In order to keep the revocation tests based on fixtures controlled by the test suite we need to host the associated revocation lists with the test suite, this PR adds a test fixture that will be fetch-able by vendors infrastructure in order to perform the revocation check.