### PR TITLE
feat: add basic verify credentialStatus tests

### DIFF
--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-14.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-14.json
@@ -1,0 +1,48 @@
+{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/citizenship/v1",
+      "https://w3id.org/vc-revocation-list-2020/v1"
+    ],
+    "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+    "type": [
+      "VerifiableCredential",
+      "PermanentResidentCard"
+    ],
+    "identifier": "83627465",
+    "name": "Permanent Resident Card",
+    "description": "Government of Example Permanent Resident Card.",
+    "issuanceDate": "2019-12-03T12:19:52Z",
+    "expirationDate": "2029-12-03T12:19:52Z",
+    "credentialStatus": {
+      "id": "https://issuer.oidp.uscis.gov/credentials/status/3#94567",
+      "type": "RevocationList2020Status",
+      "revocationListIndex": "0",
+      "revocationListCredential": "https://w3c-ccg.github.io/vc-http-api/fixtures/revocationList.json"
+    },
+    "credentialSubject": {
+      "id": "did:example:b34ca6cd37bbf23",
+      "type": [
+        "PermanentResident",
+        "Person"
+      ],
+      "givenName": "JOHN",
+      "familyName": "SMITH",
+      "gender": "Male",
+      "image": "data:image/png;base64,iVBORw0KGgo...kJggg==",
+      "residentSince": "2015-01-01",
+      "lprCategory": "C09",
+      "lprNumber": "999-999-999",
+      "commuterClassification": "C1",
+      "birthCountry": "Bahamas",
+      "birthDate": "1958-07-17"
+    },
+    "issuer": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3",
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2021-02-16T04:32:29Z",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..nFXiF3D2p-Pt6K75si3Gg8ZOP7rvbEYSP3kkXUj-d5TbrGWTfxjE6u4rb89mSRvmkxsldZH1RSdxLbAM-aP6Dw",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3#z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+    }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-15.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-15.json
@@ -1,0 +1,48 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/citizenship/v1",
+    "https://w3id.org/vc-revocation-list-2020/v1"
+  ],
+  "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+  "type": [
+    "VerifiableCredential",
+    "PermanentResidentCard"
+  ],
+  "identifier": "83627465",
+  "name": "Permanent Resident Card",
+  "description": "Government of Example Permanent Resident Card.",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "credentialStatus": {
+    "id": "https://issuer.oidp.uscis.gov/credentials/status/3#94567",
+    "type": "RevocationList2020Status",
+    "revocationListIndex": "1",
+    "revocationListCredential": "https://w3c-ccg.github.io/vc-http-api/fixtures/revocationList.json"
+  },
+  "credentialSubject": {
+    "id": "did:example:b34ca6cd37bbf23",
+    "type": [
+      "PermanentResident",
+      "Person"
+    ],
+    "givenName": "JOHN",
+    "familyName": "SMITH",
+    "gender": "Male",
+    "image": "data:image/png;base64,iVBORw0KGgo...kJggg==",
+    "residentSince": "2015-01-01",
+    "lprCategory": "C09",
+    "lprNumber": "999-999-999",
+    "commuterClassification": "C1",
+    "birthCountry": "Bahamas",
+    "birthDate": "1958-07-17"
+  },
+  "issuer": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3",
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2021-02-18T04:19:23Z",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..tM_94zQxF5LwVqaW1Q4iGnkEDyn9Mbg7A6l3d1sVd9-Yt6AOVvAILqYKWuGiXIOy64Eudw_y0UMJ4I0XpEeUAw",
+    "proofPurpose": "assertionMethod",
+    "verificationMethod": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3#z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+  }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/index.js
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/index.js
@@ -10,6 +10,7 @@ module.exports = Object.values(fixtures).map(item => {
     return {
         name: item.name,
         issuerDidMethod: typeof item.issuer === 'string' ? item.issuer : item.issuer.id,
+        credentialStatusTypes: item.credentialStatus ? Array.isArray(item.credentialStatus) ? item.credentialStatus.map(val => val.type) : [ item.credentialStatus.type ]: undefined,
         proof: item.proof,
         data: item
     };

--- a/packages/vc-http-api-test-server/__tests__/verifyCredential.spec.js
+++ b/packages/vc-http-api-test-server/__tests__/verifyCredential.spec.js
@@ -9,6 +9,7 @@ if (suiteConfig.verifyCredentialConfiguration) {
         let verifiableCredentials = suiteConfig.verifiableCredentials;
 
         const verifierEndpoint = suiteConfig.verifyCredentialConfiguration.endpoint;
+        const credentialStatusesSupported = suiteConfig.verifyCredentialConfiguration.credentialStatusesSupported;
 
         beforeEach(() => {
             verifiableCredentials = utilities.cloneObj(suiteConfig.verifiableCredentials);
@@ -18,10 +19,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe(`1. The Verifier's Verify Credential HTTP API MUST fail to verify a Verifiable Credential with a mutated signature value (ex. a mutated jws) in the proof.`, () => {
             it('should pass with no mutation', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
                 expect(res.status).toBe(200);
@@ -29,10 +30,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
             });
             it('should fail with with mutation', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 body.verifiableCredential.proof.jws += 'bar';
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -43,10 +44,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe(`2. The Verifier's Verify Credential HTTP API MUST fail to verify a Verifiable Credential with the "created" property removed from the proof.`, () => {
             it('should fail without created in proof', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 delete body.verifiableCredential.proof.created;
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -57,10 +58,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe(`3. The Verifier's Verify Credential HTTP API MUST fail to verify a Verifiable Credential with a mutated "proofPurpose" in the proof.`, () => {
             it('should fail ', async () => {
                 const body = {
-                verifiableCredential: {...verifiableCredentials[0].data},
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: {...verifiableCredentials[0].data},
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 body.verifiableCredential.proof.proofPurpose = 'bar';
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -71,10 +72,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('4. The Verifier\'s Verify Credential HTTP API MUST fail to verify a Verifiable Credential with an added property to the credential.', () => {
             it('should fail', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 body.verifiableCredential.newProp = 'foo';
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -85,10 +86,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('5. The Verifier\'s Verify Credential HTTP API MUST fail to verify a Verifiable Credential with a removed property from the credential.', () => {
             it('should fail', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 delete body.verifiableCredential.issuer;
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -99,10 +100,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('6. The Verifier\'s Verify Credential HTTP API MUST fail to verify a Verifiable Credential with a mutated property to the credential.', () => {
             it('should fail ', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 body.verifiableCredential.issuer = 'bar';
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -113,10 +114,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('7. The Verifier\'s Verify Credential HTTP API MUST fail to verify a Verifiable Credential with an added property to the proof.', () => {
             it('should fail ', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 body.verifiableCredential.proof.newProp = 'bar';
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -127,10 +128,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('8. The Verifier\'s Verify Credential HTTP API MUST fail to verify a Verifiable Credential a removed property to the proof.', () => {
             it('should fail ', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 delete body.verifiableCredential.proof.proofPurpose;
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -141,10 +142,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('9. The Verifier\'s Verify Credential HTTP API MUST fail to verify a Verifiable Credential with a mutated property to the proof.', () => {
             it('should fail ', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 body.verifiableCredential.proof.created += 'bar';
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
@@ -155,10 +156,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('10. The Verifier\'s Verify Credential HTTP API MUST adhere to the proof verification format.', () => {
             it('should pass', async () => {
                 const body = {
-                verifiableCredential: verifiableCredentials[0].data,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: verifiableCredentials[0].data,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
                 expect(res.status).toBe(200);
@@ -170,10 +171,10 @@ if (suiteConfig.verifyCredentialConfiguration) {
         describe('11. The Verifier\'s Verify Credential HTTP API MUST return a 400 HTTP response status code when the request is rejected.', () => {
             it('should have error', async () => {
                 const body = {
-                verifiableCredential: null,
-                options: {
-                    checks: ['proof'],
-                },
+                    verifiableCredential: null,
+                    options: {
+                        checks: ['proof'],
+                    },
                 };
                 const res = await httpClient.postJson(verifierEndpoint, body, {});
                 expect(res.status).toBe(400);
@@ -198,6 +199,54 @@ if (suiteConfig.verifyCredentialConfiguration) {
                 expect(res.body.checks).toEqual(['proof']);
             });
         });
+
+        if (credentialStatusesSupported) {
+            describe(`13. The Verifier\'s Verify Credential HTTP API MAY support checking the status of a credential.`, () => {
+                const fixtures = utilities.filterVerifiableCredentialsWithCredentialStatus(verifiableCredentials);
+
+                fixtures.forEach((item) => {
+                    const verifiableCredential = item.data;
+                    item.credentialStatusTypes.forEach(statusType => {
+                        // We have to introspect the general fixtures and detect if we know the credentialStatusType
+                        // because we have to map what the `status` value means
+                        if (statusType === 'RevocationList2020Status' && credentialStatusesSupported.includes(statusType)) {
+                            // Using the index that the credential occupies in the credential status list to indicate whether the
+                            // credential is revoked or not @see ../../../docs/fixtures/README.md`
+                            describe(`For status type of: ${statusType}`, () => {
+                                if (verifiableCredential.credentialStatus.revocationListIndex === "0") {
+                                    it('should pass', async () => {
+                                        const body = {
+                                            verifiableCredential,
+                                            options: {
+                                                checks: ['proof', 'credentialStatus'],
+                                            },
+                                        };
+                                        const res = await httpClient.postJson(verifierEndpoint, body, {});
+                                        expect(res.status).toBe(200);
+                                        expect(res.body.checks).toEqual(['proof', 'credentialStatus']);
+                                    });
+                                }
+                                if (verifiableCredential.credentialStatus.revocationListIndex === "1") {
+                                    it('should fail', async () => {
+                                        const body = {
+                                            verifiableCredential,
+                                            options: {
+                                                checks: ['proof', 'credentialStatus'],
+                                            },
+                                        };
+                                        const res = await httpClient.postJson(verifierEndpoint, body, {});
+                                        // TODO returning 400 from verify endpoint on failed verification is semantically incorrect, however
+                                        // it is what the API spec currently defines
+                                        expect(res.status).toBe(400);                                      
+                                    });
+                                }
+                            });
+                        }
+                    })
+                })
+            })
+        }
+        
     });
 
     describe('Verify Credential API - Interop', () => {

--- a/packages/vc-http-api-test-server/services/utilities.js
+++ b/packages/vc-http-api-test-server/services/utilities.js
@@ -1,3 +1,5 @@
+const verifiableCredentials = require("../__fixtures__/verifiableCredentials");
+
 const cloneObj = (obj) => {
   return JSON.parse(JSON.stringify(obj));
 }
@@ -5,7 +7,11 @@ const cloneObj = (obj) => {
 const filterVerifiableCredentialsByDidMethods = (verifiableCredentials, didMethods) => 
   verifiableCredentials.filter(item => didMethods.some(didMethod => item.issuerDidMethod.startsWith(didMethod)));
 
+const filterVerifiableCredentialsWithCredentialStatus = (verifiableCredentials) => 
+  verifiableCredentials.filter(item => item.credentialStatusTypes);
+
 module.exports = {
   cloneObj,
-  filterVerifiableCredentialsByDidMethods
+  filterVerifiableCredentialsByDidMethods,
+  filterVerifiableCredentialsWithCredentialStatus
 };


### PR DESCRIPTION
Adds a new test case (13) with a positive and negative test for checking whether a verifiers API can correctly detect an active and revoked credential status in accordance with `RevocationList2020Status`