### PR TITLE
feat: add bbs fixtures

### DIFF
--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-16.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-16.json
@@ -1,0 +1,41 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/bbs/v1",
+    "https://w3id.org/citizenship/v1"
+  ],
+  "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+  "type": [
+    "VerifiableCredential",
+    "PermanentResidentCard"
+  ],
+  "name": "Permanent Resident Card",
+  "description": "Government of Example Permanent Resident Card.",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "credentialSubject": {
+    "id": "did:example:b34ca6cd37bbf23",
+    "type": [
+      "PermanentResident",
+      "Person"
+    ],
+    "givenName": "JOHN",
+    "familyName": "SMITH",
+    "gender": "Male",
+    "image": "data:image/png;base64,iVBORw0KGgo...kJggg==",
+    "residentSince": "2015-01-01",
+    "lprCategory": "C09",
+    "lprNumber": "999-999-999",
+    "commuterClassification": "C1",
+    "birthCountry": "Bahamas",
+    "birthDate": "1958-07-17"
+  },
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "proof": {
+    "type": "BbsBlsSignature2020",
+    "created": "2021-02-23T19:31:12Z",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "qPrB+1BLsVSeOo1ci8dMF+iR6aa5Q6iwV/VzXo2dw94ctgnQGxaUgwb8Hd68IiYTVabQXR+ZPuwJA//GOv1OwXRHkHqXg9xPsl8HcaXaoWERanxYClgHCfy4j76Vudr14U5AhT3v8k8f0oZD+zBIUQ==",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-17.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-17.json
@@ -1,0 +1,33 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/citizenship/v1",
+    "https://w3id.org/security/bbs/v1"
+  ],
+  "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+  "type": [
+    "PermanentResidentCard",
+    "VerifiableCredential"
+  ],
+  "description": "Government of Example Permanent Resident Card.",
+  "name": "Permanent Resident Card",
+  "credentialSubject": {
+    "id": "did:example:b34ca6cd37bbf23",
+    "type": [
+      "Person",
+      "PermanentResident"
+    ],
+    "birthDate": "1958-07-17"
+  },
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "proof": {
+    "type": "BbsBlsSignatureProof2020",
+    "created": "2021-02-23T19:31:12Z",
+    "nonce": "G/hn9Ca9bIWZpJGlhnr/41r8RB0OO0TLChZASr3QJVztdri/JzS8Zf/xWJT5jW78zlM=",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "ABgA/wYfjSxZz8DBQHTIuX+F0MmeskKbywg6NSMGHOqJ9LvYrfaakmMaPh+UsJxIK1z5v3NuiRP4OGhIbYgjo0KovKMZzluSzCGwzAyXui2hnFlrySj3RP+WNmWd+6QZQ6bEm+pyhNC6VrEMVDxJ2TH7DShbx6GFQ6RLvuS0Xf38GuOhX26+5RJ9RBs5Qaj4/UKsTfc9AAAAdKGdxxloz3ZJ2QnoFlqicO6MviT8yzeyf5gILHg8YUjNIAVJJNsh26kBqIdQkaROpQAAAAIVX5Y1Jy9hgEQgqUld/aGN2uxOLZAJsri9BRRHoFNWkkcF73EV4BE9+Hs+8fuvX0SNDAmomTVz6vSrq58bjHZ+tmJ5JddwT1tCunHV330hqleI47eAqwGuY9hdeSixzfL0/CGnZ2XoV2YAybVTcupSAAAACw03E8CoLBvqXeMV7EtRTwMpKQmEUyAM5iwC2ZaAkDLnFOt2iHR4P8VExFmOZCl94gt6bqWuODhJ5mNCJXjEO9wmx3RNM5prB7Au5g59mdcuuY/GCKmKNt087BoHYG//dEFi4Q+bRpVE5MKaGv/JZd/LmPAfKfuj5Tr37m0m3hx6HROmIv0yHcakQlNQqM6QuRQLMr2U+nj4U4OFQZfMg3A+f6fVS6T18WLq4xbHc/2L1bYhIw+SjXwkj20cGhEBsmFOqj4oY5AzjN1t4gfzb5itxQNkZFVE2IdBP9v/Ck8rMQLmxs68PDPcp6CAb9dvMS0fX5CTTbJHqG4XEjYRaBVG0Ji5g3vTpGVAA4jqOzpTbxKQawA4SvddV8NUUm4N/zCeWMermi3yRhZRl1AXa8BqGO+mXNI7yAPjn1YDoGliQkoQc5B4CYY/5ldP19XS2hV5Ak16AJtD4tdeqbaX0bo=",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-18.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-18.json
@@ -1,0 +1,28 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
+    "https://w3id.org/security/bbs/v1"
+  ],
+  "id": "http://example.gov/credentials/3732",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "issuanceDate": "2020-03-10T04:24:12.164Z",
+  "credentialSubject": {
+    "id": "did:key:z5TcESXuYUE9aZWYwSdrUEGK1HNQFHyTt4aVpaCTVZcDXQmUheFwfNZmRksaAbBneNm5KyE52SdJeRCN1g6PJmF31GsHWwFiqUDujvasK3wTiDr3vvkYwEJHt7H5RGEKYEp1ErtQtcEBgsgY2DA9JZkHj1J9HZ8MRDTguAhoFtR4aTBQhgnkP4SwVbxDYMEZoF2TMYn3s#zUC7LTa4hWtaE9YKyDsMVGiRNqPMN3s4rjBdB3MFi6PcVWReNfR72y3oGW2NhNcaKNVhMobh7aHp8oZB3qdJCs7RebM2xsodrSm8MmePbN25NTGcpjkJMwKbcWfYDX7eHCJjPGM",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  },
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "proof": {
+    "type": "BbsBlsSignature2020",
+    "created": "2021-02-23T19:36:07Z",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "qSjCNJzoDV3hv3gBPoUNN9m5lj8saDBBxC0iDHuFTXXz4PbbUhecmn/L3rPoGuySNatqC4I8VE22xQy0RAowIxoZCC+B2mZQIAb+/JGlXeAlWgEQc71WipfvsfqSn+KmR/rN1FREOy3rtSltyQ92rA==",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-19.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-19.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
+    "https://w3id.org/security/bbs/v1"
+  ],
+  "id": "http://example.gov/credentials/3732",
+  "type": [
+    "UniversityDegreeCredential",
+    "VerifiableCredential"
+  ],
+  "credentialSubject": {
+    "id": "did:key:z5TcESXuYUE9aZWYwSdrUEGK1HNQFHyTt4aVpaCTVZcDXQmUheFwfNZmRksaAbBneNm5KyE52SdJeRCN1g6PJmF31GsHWwFiqUDujvasK3wTiDr3vvkYwEJHt7H5RGEKYEp1ErtQtcEBgsgY2DA9JZkHj1J9HZ8MRDTguAhoFtR4aTBQhgnkP4SwVbxDYMEZoF2TMYn3s#zUC7LTa4hWtaE9YKyDsMVGiRNqPMN3s4rjBdB3MFi6PcVWReNfR72y3oGW2NhNcaKNVhMobh7aHp8oZB3qdJCs7RebM2xsodrSm8MmePbN25NTGcpjkJMwKbcWfYDX7eHCJjPGM",
+    "degree": {
+      "id": "urn:bnid:_:c14n0",
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  },
+  "issuanceDate": "2020-03-10T04:24:12.164Z",
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "proof": {
+    "type": "BbsBlsSignatureProof2020",
+    "created": "2021-02-23T19:37:24Z",
+    "nonce": "lEixQKDQvRecCifKl789TQj+Ii6YWDLSwn3AxR0VpPJ1QV5htod/0VCchVf1zVM0y2E=",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "AAwP/4nFun/RtaXtUVTppUimMRTcEROs3gbjh9iqjGQAsvD+ne2uzME26gY4zNBcMKpvyLD4I6UGm8ATKLQI4OUiBXHNCQZI4YEM5hWI7AzhFXLEEVDFL0Gzr4S04PvcJsmV74BqST8iI1HUO2TCjdT1LkhgPabP/Zy8IpnbWUtLZO1t76NFwCV8+R1YpOozTNKRQQAAAHSpyGry6Rx3PRuOZUeqk4iGFq67iHSiBybjo6muud7aUyCxd9AW3onTlV2Nxz8AJD0AAAACB3FmuAUcklAj5cdSdw7VY57y7p4VmfPCKaEp1SSJTJRZXiE2xUqDntend+tkq+jjHhLCk56zk5GoZzr280IeuLne4WgpB2kNN7n5dqRpy4+UkS5+kiorLtKiJuWhk+OFTiB8jFlTbm0dH3O3tm5CzQAAAAIhY6I8vQ96tdSoyGy09wEMCdWzB06GElVHeQhWVw8fukq1dUAwWRXmZKT8kxDNAlp2NS7fXpEGXZ9fF7+c1IJp",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-20.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-20.json
@@ -1,0 +1,46 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/bbs/v1",
+    "https://w3id.org/vaccination/v1"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "VaccinationCertificate"
+  ],
+  "id": "urn:uvci:af5vshde843jf831j128fj",
+  "name": "COVID-19 Vaccination Certificate",
+  "description": "COVID-19 Vaccination Certificate",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "credentialSubject": {
+    "id": "did:example:12345",
+    "type": "VaccinationEvent",
+    "batchNumber": "1183738569",
+    "administeringCentre": "MoH",
+    "healthProfessional": "MoH",
+    "countryOfVaccination": "NZ",
+    "recipient": {
+      "type": "VaccineRecipient",
+      "givenName": "JOHN",
+      "familyName": "SMITH",
+      "gender": "Male",
+      "birthDate": "1958-07-17"
+    },
+    "vaccine": {
+      "type": "Vaccine",
+      "disease": "COVID-19",
+      "atcCode": "J07BX03",
+      "medicinalProductName": "COVID-19 Vaccine Moderna",
+      "marketingAuthorizationHolder": "Moderna Biotech"
+    }
+  },
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "proof": {
+    "type": "BbsBlsSignature2020",
+    "created": "2021-02-25T02:51:44Z",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "kADjbimx6+aMwHbQQp8e8YwkQWBVWHfEekSgghpUVH2ogtXr4Uofp4E+R7ZGCxlSKyWnbrzCQFNjExczECZLFeLoDP22DDIJPwXxI+0bES8ubILwapeNLpyjrJb9jYOWhUGfRHlbXQR5LWRYd9jPjA==",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-21.json
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/case-21.json
@@ -1,0 +1,31 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/bbs/v1",
+    "https://w3id.org/vaccination/v1"
+  ],
+  "id": "urn:uvci:af5vshde843jf831j128fj",
+  "type": [
+    "VaccinationCertificate",
+    "VerifiableCredential"
+  ],
+  "description": "COVID-19 Vaccination Certificate",
+  "name": "COVID-19 Vaccination Certificate",
+  "credentialSubject": {
+    "id": "did:example:12345",
+    "type": "VaccinationEvent",
+    "batchNumber": "1183738569",
+    "countryOfVaccination": "NZ"
+  },
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "proof": {
+    "type": "BbsBlsSignatureProof2020",
+    "created": "2021-02-25T02:51:44Z",
+    "nonce": "8Q4Xt+C5gsza5Jnw45mG+jAZZd0IbMRsQgYDX5jikt1twLt3SrcKBr1ABapZAA55e+s=",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "AB0AB/mfjX+mLfWSJYykFo9VRtO7XiAYixzmsWftNhUGBwXjH2sPScAv2oR6D5L2skcxF6evgYik6oxgXk/aqnDTPqo45Q8qiNR56ssMd1bJYd+CoUHNZofzoCerdcnWlb//NGtTj0uyPli3vdDlnYuy2rqLPzEUBwNWrgHKBWIGPFvqm4pqmEQ+MBxmg+xPXvseJ892AAAAdK3u/izyGMgEgPog8Z7A9luE/6O/R+5WptR08p5BXQNBmfLMiKHtBJPoxBljGMbd/wAAAAIM0sCGszUhPWJGOPE7ninSWvi4fW3k/t8NYVn0JiF/ez3KbcQr3C8xaYQqxY9f4FO2xm5Bt5tZ+6S/5CxSei6ylpSCX/uNO1noldIX1PKDdO+uhNetDa11ufs1EGbZnjXCC5tqfva5tRz8RfZYl6KQAAAAEG66goFUu22oItTsHsV576HdqyquDCl3tDvFGvdBCj/KIb7eBSk4gCqbTElCJxNG1VAXg+L9p+9b2Afu9FnM9ktPyxQx5uwdqPs4kb/cq2Tg+HMtS3C34JMH94xCoEYiDWCKrXt8yUxufE8dKHUZHwl/1OAGHo6jqubiJhTHNSxSbV2MVQwSeFoscsiGx4b3lJ2gUOPRW3xAO5r2ngBckkRL9mdq1QmQM3KVF0qruFM28qhTyQpLYKFnWdak79QKcB58A4gt1MrzPlvNzVZ64rFUw2XnT6KKUrhE2GWAtylIK/jQDNUjlF6BZDwDxGQo0xjleMNU6clyEuKPpA/PTPQ5En7O8whrQEOEL9z16mwxmKLOlV8FhsTbrMSoWJI/T1umsJiw3iAOgNsEl1e8s/QquhmDlhr6M/8ZF2np0C9sRhOODrMyS5kaKjXs8ASuOHw5txrnI4j8w0j79JSLRug4uLtW9boqeSx0HOKryD2zubSbQbbBR/RLkXbZMMmBdmlg9wdjzMELCNGOm8H5Yr7OmVEzIivOKHIz4kVPuqAPbePB4UyX4JMFQyF3D88T/0HEGO9n2RYWe1Dor9FiGWkiUsIwNZdxXRlrr2rPBt3mnUQSD9LL8qb6vBinKxGQNV2TjvcNtWmjZKWHKwczooWB9NAYv+Bf9fbTfu7Yxo9y",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/index.js
+++ b/packages/vc-http-api-test-server/__fixtures__/verifiableCredentials/index.js
@@ -11,7 +11,7 @@ module.exports = Object.values(fixtures).map(item => {
         name: item.name,
         issuerDidMethod: typeof item.issuer === 'string' ? item.issuer : item.issuer.id,
         credentialStatusTypes: item.credentialStatus ? Array.isArray(item.credentialStatus) ? item.credentialStatus.map(val => val.type) : [ item.credentialStatus.type ]: undefined,
-        proof: item.proof,
+        proofType: item.proof.type,
         data: item
     };
 });

--- a/packages/vc-http-api-test-server/__tests__/verifyCredential.spec.js
+++ b/packages/vc-http-api-test-server/__tests__/verifyCredential.spec.js
@@ -6,7 +6,7 @@ const utilities = require('../services/utilities');
 if (suiteConfig.verifyCredentialConfiguration) {
     describe('Verify Credential API - Conformance', () => {
         // Load in the static test fixtures
-        let verifiableCredentials = suiteConfig.verifiableCredentials;
+        let verifiableCredentials = utilities.filterVerifiableCredentialsForVendorConfig(suiteConfig.verifiableCredentials, suiteConfig.verifyCredentialConfiguration);
 
         const verifierEndpoint = suiteConfig.verifyCredentialConfiguration.endpoint;
         const credentialStatusesSupported = suiteConfig.verifyCredentialConfiguration.credentialStatusesSupported;
@@ -251,12 +251,12 @@ if (suiteConfig.verifyCredentialConfiguration) {
 
     describe('Verify Credential API - Interop', () => {
         // Load in the static test fixtures
-        let verifiableCredentials = utilities.filterVerifiableCredentialsByDidMethods(suiteConfig.verifiableCredentials, suiteConfig.verifyCredentialConfiguration.didMethodsSupported);;
+        let verifiableCredentials = utilities.filterVerifiableCredentialsForVendorConfig(suiteConfig.verifiableCredentials, suiteConfig.verifyCredentialConfiguration);
 
         const verifierEndpoint = suiteConfig.verifyCredentialConfiguration.endpoint;
 
         verifiableCredentials.forEach((verifiableCredential) => {
-            describe(`Can verify ${verifiableCredential.name} verifiable credential, with issuer DID method ${verifiableCredential.issuerDidMethod} and linked data proof suite ${verifiableCredential.linkedDataProofSuite}`, () => {
+            describe(`Can verify ${verifiableCredential.name} verifiable credential, with issuer DID method ${verifiableCredential.issuerDidMethod} and linked data proof suite ${verifiableCredential.proofType}`, () => {
                 it('should pass with no mutation', async () => {
                     const body = {
                     verifiableCredential: verifiableCredential.data,

--- a/packages/vc-http-api-test-server/services/utilities.js
+++ b/packages/vc-http-api-test-server/services/utilities.js
@@ -1,17 +1,33 @@
-const verifiableCredentials = require("../__fixtures__/verifiableCredentials");
-
 const cloneObj = (obj) => {
   return JSON.parse(JSON.stringify(obj));
 }
 
+const filterVerifiableCredentialsForVendorConfig = (verifiableCredentials, config) =>
+  verifiableCredentials.filter(item =>
+    checkVerifiableCredentialIssuerDidMethod(item, config.didMethodsSupported) &&
+    checkVerifiableCredentialLinkedDataProofType(item, config.linkedDataProofSuitesSupported) &&
+    (!item.credentialStatusTypes || !config.credentialStatusesSupported || checkVerifiableCredentialCredentialStatus(item, config.credentialStatusesSupported))
+  );
+
+const checkVerifiableCredentialLinkedDataProofType = (element, supportedProofTypes) => supportedProofTypes.some(proofType => element.proofType === proofType);
+
+const checkVerifiableCredentialIssuerDidMethod = (element, supportedDidMethods) => supportedDidMethods.some(didMethod => element.issuerDidMethod.startsWith(didMethod));
+
+const checkVerifiableCredentialCredentialStatus = (element, supportCredentialStatuses) => supportCredentialStatuses.some(credentialStatus => element.credentialStatusTypes && element.credentialStatusTypes.includes(credentialStatus));
+
+const filterVerifiableCredentialsByLinkedDataProofType = (verifiableCredentials, proofTypes) =>
+  verifiableCredentials.filter(item => checkVerifiableCredentialLinkedDataProofType(item, proofType));
+
 const filterVerifiableCredentialsByDidMethods = (verifiableCredentials, didMethods) => 
-  verifiableCredentials.filter(item => didMethods.some(didMethod => item.issuerDidMethod.startsWith(didMethod)));
+  verifiableCredentials.filter(item => checkVerifiableCredentialIssuerDidMethod(item, didMethods));
 
 const filterVerifiableCredentialsWithCredentialStatus = (verifiableCredentials) => 
   verifiableCredentials.filter(item => item.credentialStatusTypes);
 
 module.exports = {
   cloneObj,
+  filterVerifiableCredentialsByLinkedDataProofType,
   filterVerifiableCredentialsByDidMethods,
-  filterVerifiableCredentialsWithCredentialStatus
+  filterVerifiableCredentialsWithCredentialStatus,
+  filterVerifiableCredentialsForVendorConfig
 };


### PR DESCRIPTION
PR dependent on #124 being merged ahead.

This PR adds optional test fixtures for the verifyCredential endpoint test cases for those who support BbsBlsSignature2020