### PR TITLE
Change "assertionMethod" option to "verificationMethod" in issueCredential test.

### DIFF
--- a/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js
+++ b/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js
@@ -69,7 +69,7 @@ if (suiteConfig.issueCredentialConfiguration) {
             expect(res.status).toBe(400);
         });
 
-        it(`6. The Issuer's Issue Credential HTTP API MUST reject if the value of "options.assertionMethod" in the body of the POST request does not exist.`, async () => {
+        it(`6. The Issuer's Issue Credential HTTP API MUST reject if the value of "options.verificationMethod" in the body of the POST request does not exist.`, async () => {
             const body = {
               credential: {
                 ...credentials[0].data,
@@ -77,7 +77,7 @@ if (suiteConfig.issueCredentialConfiguration) {
               },
               options: {
                 ...value.options[0],
-                assertionMethod: 'foo',
+                verificationMethod: 'foo',
               },
             };
             const res = await httpClient.postJson(value.endpoint, body, {});


### PR DESCRIPTION
"assertionMethod" doesn't exist as an option for `/credentials/issue`.

See https://github.com/w3c-ccg/vc-http-api/blob/master/docs/vc-http-api.yml#L221.

Fixes https://github.com/w3c-ccg/vc-http-api/issues/112.