### PR TITLE
Add credential exchange APIs for holders

### DIFF
--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -113,6 +113,65 @@ paths:
           description: invalid input!
         "500":
           description: error!
+  /presentations/available:
+    post:
+      tags:
+        - Holder
+      summary: Notifies a holder of an available presentation.
+      operationId: notifyPresentationAvailable
+      description:
+        This API is the first part of a holder to holder credential exchange over http.
+        The server MAY reply with a query for the client to proceed with a presentation.
+      requestBody:
+        description: Details the client provides to the server to help it decide if the presentation should be made.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NotifyPresentationAvailableRequest"
+
+      responses:
+        "200":
+          description: Proceed with presentation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotifyPresentationAvailableResponse"
+        "400":
+          description: Request for presentation is malformed
+        "501":
+          description: Not implemented
+        "500":
+          description: internal error
+  /presentations/submissions:
+    post:
+      tags:
+        - Holder
+      summary: Provide a presentation for a holder to store.
+      operationId: storePresentation
+      description: Present from a client holder to a server holder, for the purpose of verification AND storage.
+      requestBody:
+        description: Details the client provides to the server to help it decide if the presentation should be made.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StorePresentationRequest"
+      responses:
+        "202":
+          description: Presentation accepted
+        "400":
+          description: Presentation is malformed
+        "401":
+          description: Presentation did not contain a proof
+        "402":
+          description: Payment required
+        "403":
+          description: Presentation verification failed
+        "425":
+          description: Server is unwilling to risk processing a request that might be replayed
+        "501":
+          description: Not implemented
+        "500":
+          description: internal error
   /credentials/verify:
     post:
       tags:
@@ -592,6 +651,91 @@ components:
           $ref: "#/components/schemas/PresentCredentialOptions"
     ProvePresentationResponse:
       $ref: "#/components/schemas/VerifiablePresentation"
+    NotifyPresentationAvailableRequest:
+      type: object
+      properties:
+        query:
+          type: object
+          description: See https://w3c-ccg.github.io/vp-request-spec/#format
+          properties:
+            type:
+              type: string
+              description: "The type of query the server should reply with."
+            credentialQuery:
+              type: object
+              description: "Details of the client's available presentation"
+
+      example:
+        {
+          "query":
+            [
+              {
+                "type": "RequestQueryByFrame",
+                "credentialQuery":
+                  [
+                    {
+                      "type":
+                        [
+                          "VerifiableCredential",
+                          "CommercialInvoiceCertificate",
+                        ],
+                      "reason": "Wallet XYZ is ready to selectively disclose new credentials.",
+                    },
+                  ],
+              },
+            ],
+        }
+
+    NotifyPresentationAvailableResponse:
+      type: object
+      properties:
+        query:
+          type: object
+          description: See https://w3c-ccg.github.io/vp-request-spec/#format
+        domain:
+          type: string
+          description: See https://w3id.org/security#domain
+        challenge:
+          type: string
+          description: See https://w3id.org/security#challenge
+      example:
+        {
+          "query":
+            [
+              {
+                "type": "QueryByFrame",
+                "credentialQuery":
+                  {
+                    "frame":
+                      {
+                        "@context":
+                          [
+                            "https://www.w3.org/2018/credentials/v1",
+                            "https://w3id.org/traceability/v1",
+                            "https://w3id.org/bbs/v1",
+                          ],
+                        "type":
+                          [
+                            "VerifiableCredential",
+                            "CommercialInvoiceCertificate",
+                          ],
+                        "credentialSubject":
+                          {
+                            "@explicit": true,
+                            "type": ["CommercialInvoice"],
+                            "purchaseDate": {},
+                            "destinationCountry": {},
+                          },
+                      },
+                  },
+              },
+            ],
+          "domain": "jobs.example.com",
+          "challenge": "3182bdea-63d9-11ea-b6de-3b7c1404d57f",
+        }
+    StorePresentationRequest:
+      $ref: "#/components/schemas/VerifiablePresentation"
+
     VerifyCredentialRequest:
       type: object
       properties:

--- a/docs/vc-http-api.yml
+++ b/docs/vc-http-api.yml
@@ -121,7 +121,7 @@ paths:
       operationId: notifyPresentationAvailable
       description:
         This API is the first part of a holder to holder credential exchange over http.
-        The server MAY reply with a query for the client to proceed with a presentation.
+        Notifies this server-holder that the client-holder (caller) is prepared to deliver a presentation compliant with the provided Verifiable Presentation Request query. This is the first part of a presentation exchange over this HTTP API. This server-holder MUST return the required 'domain' and 'challenge' parameters for the Presentation. This server-holder MAY reply with an alternate Verifiable Presentation Request query if it requires something different than the one proposed by the client-holder. The client-holder MUST return a Presentation in accordance with the response parameters.
       requestBody:
         description: Details the client provides to the server to help it decide if the presentation should be made.
         content:
@@ -148,7 +148,7 @@ paths:
         - Holder
       summary: Provide a presentation for a holder to store.
       operationId: storePresentation
-      description: Present from a client holder to a server holder, for the purpose of verification AND storage.
+      description: "Delivery endpoint for a client-holder to provide a presentation in compliance with the Verifiable Presentation Request provided in the Notification call. This server-holder MUST match the 'domain' and 'challenge' to a 'domain' and 'challenge' previously sent in a Notification Response, and not already received. The server-holder MUST verify the Presentation. The server MUST store the Presentation if verification passes."
       requestBody:
         description: Details the client provides to the server to help it decide if the presentation should be made.
         content:


### PR DESCRIPTION
- Notify a holder of an available presentation
- Present to a holder (telling them to store vs  the "verifyPresentation" operation which is not stateful, and not a holder API)