### PR TITLE
Add initial structure for VC HTTP API specification.

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,0 +1,316 @@
+/* globals omitTerms, respecConfig, $, require */
+/* DID WG common Javascript ReSpec functions */
+/*  ... stolen from Gregg Kellogg of the JSON-LD 1.1 Working Group */
+/*  ... who stole it from Manu Sporny of the JSON-LD 1.0 Working Group */
+/*  ... who stole it from Shane McCarron, that beautiful, beautiful man. */
+var ccg = {
+  // Add as the respecConfig localBiblio variable
+  // Extend or override global respec references
+  localBiblio: {
+    "DID-SPEC-REGISTRIES": {
+      title: "DID Specification Registries",
+      href: "https://w3c.github.io/did-spec-registries/",
+      authors: [
+        "Orie Steele",
+        "Manu Sporny"
+      ],
+      status: "ED",
+      publisher: "Decentralized Identifier Working Group"
+    },
+    "REST": {
+      title: "Architectural Styles and the Design of Network-based Software Architectures",
+      date: "2000",
+      href: "http://www.ics.uci.edu/~fielding/pubs/dissertation/",
+      authors: [
+        "Fielding, Roy Thomas"
+      ],
+      publisher: "University of California, Irvine."
+    },
+    "VC-USECASES": {
+      title: "Verifiable Claims Use Cases",
+      href: "https://www.w3.org/TR/verifiable-claims-use-cases/",
+      authors: [
+        "Shane McCarron",
+        "Daniel Burnett",
+        "Gregg Kellogg",
+        "Brian Sletten",
+        "Manu Sporny"
+      ],
+      status: "FPWD",
+      publisher: "Verifiable Claims Working Group"
+    },
+    "DID-USE-CASES": {
+      title: "Decentralized Identifier Use Cases",
+      href: "https://www.w3.org/TR/did-use-cases/",
+      authors: [
+        "Joe Andrieu",
+        "Kim Hamilton Duffy",
+        "Ryan Grant",
+        "Adrian Gropper"
+      ],
+      status: "ED",
+      publisher: "Decentralized Identifier Working Group"
+    },
+    // aliases to known references
+    "HTTP-SIGNATURES": {
+      aliasOf: "http-signatures"
+    },
+    "MACAROONS": {
+      title: 'Macaroons',
+      // TODO: create spec
+      href: 'http://macaroons.io/',
+      authors: ['Arnar Birgisson', 'Joe Gibbs Politz', 'Úlfar Erlingsson',
+        'Ankur Taly', 'Michael Vrable', 'Mark Lentczner'],
+      status: 'unofficial',
+      publisher: 'Credentials Community Group'
+    },
+    'OPEN-BADGES': {
+      title: 'Open Badges',
+      href: 'https://github.com/openbadges/openbadges-specification',
+      authors: ['Brian Brennan', 'Mike Larsson', 'Chris McAvoy',
+        'Nate Otto', 'Kerri Lemoie'],
+      status:   'BA-DRAFT',
+      publisher:  'Badge Alliance Standard Working Group'
+    },
+    'RDF-NORMALIZATION': {
+      title: 'RDF Dataset Normalization',
+      href: 'http://json-ld.github.io/normalization/spec/',
+      authors: ['Dave Longley', 'Manu Sporny'],
+      status:   'CG-DRAFT',
+      publisher:  'Credentials W3C Community Group'
+    },
+    "LD-PROOFS": {
+      title: "Linked Data Proofs",
+      href: "https://w3c-dvcg.github.io/ld-proofs/",
+      authors: [
+        "Manu Sporny",
+        "Dave Longley"
+      ],
+      status: "CG-DRAFT",
+      publisher: "Digital Verification Community Group"
+    },
+    "LD-SIGNATURES": {
+      title: "Linked Data Signatures",
+      href: "https://w3c-dvcg.github.io/ld-signatures/",
+      authors: [
+        "Manu Sporny",
+        "Dave Longley"
+      ],
+      status: "CG-DRAFT",
+      publisher: "Digital Verification Community Group"
+    },
+    "MATRIX-URIS": {
+      title: "Matrix URIs - Ideas about Web Architecture",
+      date: "December 1996",
+      href: "https://www.w3.org/DesignIssues/MatrixURIs.html",
+      authors: [
+        "Tim Berners-Lee"
+      ],
+      status: "Personal View"
+    },
+    "HASHLINK": {
+      title: "Cryptographic Hyperlinks",
+      date: "December 2018",
+      href: "https://tools.ietf.org/html/draft-sporny-hashlink-05",
+      authors: [
+        "Manu Sporny"
+      ],
+      status: "Internet-Draft",
+      publisher: "IETF"
+    },
+    "BASE58": {
+      title: "The Base58 Encoding Scheme",
+      date: "October 2020",
+      href: "https://tools.ietf.org/html/draft-msporny-base58",
+      authors: [
+        "Manu Sporny"
+      ],
+      status: "Internet-Draft",
+      publisher: "IETF"
+    },
+    "DNS-DID": {
+      title: "The Decentralized Identifier (DID) in the DNS",
+      date: "February 2019",
+      href: "https://datatracker.ietf.org/doc/draft-mayrhofer-did-dns/",
+      authors: [
+        "Alexander Mayrhofer",
+        "Dimitrij Klesev",
+        "Markus Sabadello"
+      ],
+      status: "Internet-Draft"
+    },
+    "DID-RESOLUTION": {
+      title: "Decentralized Identifier Resolution",
+      href: "https://w3c-ccg.github.io/did-resolution/",
+      authors: [
+        "Markus Sabadello",
+        "Dmitri Zagidulin"
+      ],
+      status: "Draft Community Group Report",
+      publisher: "Credentials Community Group"
+    },
+    "DID-RUBRIC": {
+      title: "Decentralized Characteristics Rubric v1.0",
+      href: "https://w3c.github.io/did-rubric/",
+      authors: [
+        "Joe Andrieu"
+      ],
+      status: "Draft Community Group Report",
+      publisher: "Credentials Community Group"
+    },
+    "PRIVACY-BY-DESIGN": {
+      title: "Privacy by Design",
+      href: "https://iapp.org/media/pdf/resource_center/pbd_implement_7found_principles.pdf",
+      authors: [
+        "Ann Cavoukian"
+      ],
+      date: "2011",
+      publisher: "Information and Privacy Commissioner"
+    },
+    "MULTIBASE": {
+      title: "The Multibase Encoding Scheme",
+      date: "February 2021",
+      href: "https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03",
+      authors: [
+        "Juan Benet",
+        "Manu Sporny"
+      ],
+      status: "Internet-Draft",
+      publisher: "IETF"
+    },
+    "JSON-LD11": {
+      title: "JSON-LD 1.1",
+      date: "2020-07-16",
+      authors: [
+        "Gregg Kellogg", "Pierre-Antoine Champin", "Dave Longley"
+      ],
+      status: "W3C Recommendation",
+      publisher: "W3C",
+      href: "https://www.w3.org/TR/json-ld11/"
+    },
+    "VC-DATA-MODEL": {
+      title: "Verifiable Credentials Data Model 1.0",
+      date: "2019-11-19",
+      authors: [
+        "Manu Sporny", "Grant Noble", "Dave Longley", "Daniel Burnett", "Brent Zundel"
+      ],
+      status: "W3C Recommendation",
+      publisher: "W3C",
+      href: "https://www.w3.org/TR/vc-data-model/"
+    }
+  }
+};
+
+
+require(["core/pubsubhub"], (respecEvents) => {
+  "use strict";
+
+  console.log("RESPEC EVENTS", respecEvents);
+
+  respecEvents.sub('end-all', (message) => {
+    console.log("END EVENT", message);
+    // remove data-cite on where the citation is to ourselves.
+    const selfDfns = document.querySelectorAll("dfn[data-cite^='" + respecConfig.shortName.toUpperCase() + "#']");
+    for (const dfn of selfDfns) {
+      delete dfn.dataset.cite;
+    }
+
+    // Update data-cite references to ourselves.
+    const selfRefs = document.querySelectorAll("a[data-cite^='" + respecConfig.shortName.toUpperCase() + "#']");
+    for (const anchor of selfRefs) {
+      anchor.href= anchor.dataset.cite.replace(/^.*#/,"#");
+      delete anchor.dataset.cite;
+    }
+
+  });
+
+});
+
+// Removes dfns that aren't referenced anywhere in the spec.
+// To ensure a definition appears in the Terminology section, use
+//  and link to it!
+// This is triggered by postProcess in the respec config.
+function restrictRefs(config, document){
+
+  // Get set of ids internal dfns referenced in the spec body
+  const internalDfnLinks = document.querySelectorAll("a.internalDFN");
+  let internalDfnIds = new Set();
+  for (const dfnLink of internalDfnLinks) {
+    const dfnHref = dfnLink.href.split("#")[1];
+    internalDfnIds.add(dfnHref);
+  }
+
+  // Remove unused dfns from the termlist
+  const termlist = document.querySelector(".termlist");
+  const linkIdsInDfns = [];
+  for (const child of termlist.querySelectorAll("dfn")){
+    if (!internalDfnIds.has(child.id)){
+      let dt = child.closest("dt");
+      let dd = dt.nextElementSibling;
+
+      // Get internal links from dfns we're going to remove
+      //  because these show up in the dfn-panels later and then
+      //  trigger the local-refs-exist linter (see below)
+      const linksInDfn = dd.querySelectorAll("a.internalDFN");
+      for (link of linksInDfn) {
+        linkIdsInDfns.push(link.id);
+      }
+
+      termlist.removeChild(dt);
+      termlist.removeChild(dd);
+    }
+  }
+
+  // Remove unused dfns from the dfn-panels
+  //  (these are hidden, but still trigger the local-refs-exist linter)
+  //  (this seems like a hack, there's probably a better way to hook into respec
+  //   before it gets to this point)
+  const dfnPanels = document.querySelectorAll(".dfn-panel");
+  for (const panel of dfnPanels) {
+    if (!internalDfnIds.has(panel.querySelector(".self-link").href.split("#")[1])){
+      panel.parentNode.removeChild(panel);
+    }
+
+    // Remove references to dfns we removed which link to other dfns
+    const panelLinks = panel.querySelectorAll("li a");
+    for (const link of panelLinks) {
+      if (linkIdsInDfns.includes(link.href.split("#")[1])) {
+        link.parentNode.removeChild(link);
+      }
+    }
+  }
+
+}
+
+function _esc(s) {
+  return s.replace(/&/g,'&amp;')
+    .replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;')
+    .replace(/</g,'&lt;');
+}
+
+function reindent(text) {
+  // TODO: use trimEnd when Edge supports it
+  const lines = text.trimRight().split("\n");
+  while (lines.length && !lines[0].trim()) {
+    lines.shift();
+  }
+  const indents = lines.filter(s => s.trim()).map(s => s.search(/[^\s]/));
+  const leastIndent = Math.min(...indents);
+  return lines.map(s => s.slice(leastIndent)).join("\n");
+}
+
+function updateExample(doc, content) {
+  // perform transformations to make it render and prettier
+  return _esc(reindent(unComment(doc, content)));
+}
+
+function unComment(doc, content) {
+  // perform transformations to make it render and prettier
+  return content
+    .replace(/<!--/, '')
+    .replace(/-->/, '')
+    .replace(/< !\s*-\s*-/g, '<!--')
+    .replace(/-\s*- >/g, '-->')
+    .replace(/-\s*-\s*&gt;/g, '--&gt;');
+}

--- a/index.html
+++ b/index.html
@@ -23,14 +23,14 @@
   <script class="remove" type="text/javascript">
   var respecConfig = {
     // the W3C WG and public mailing list
-    group: "ccg",
+    group: "credentials",
     wgPublicList: "public-credentials",
 
     // the specification's short name, as in http://www.w3.org/TR/short-name/
     shortName: "vc-http-api",
 
     // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
-    specStatus: "CGDRAFT",
+    specStatus: "CG-DRAFT",
 
     // W3C Candidate Recommendation information
     //crEnd: "2021-05-04",
@@ -68,7 +68,9 @@
     postProcess: [/*add_reqlist_button*/, restrictRefs],
 
     // list of specification editors
-    editors: [],
+    editors: [{
+      name: "TBD"
+    }],
 
     // list of specification authors
     authors: []

--- a/index.html
+++ b/index.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Verifiable Credentials HTTP API v0.3</title>
+  <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
+  <!--
+    === NOTA BENE ===
+    For the three scripts below, if your spec resides on dev.w3 you can check
+    them out in the same tree and use relative links so that they'll work
+    offline.
+  -->
+
+  <script class="remove"
+    src="https://unpkg.com/browse/jquery/dist/jquery.min.js"></script>
+  <script class="remove"
+    src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+  <script class="removeOnSave"
+    src="https://unpkg.com/reqlist/lib/reqlist.js"></script>
+  <link class="removeOnSave" rel="stylesheet" type="text/css"
+    href="https://unpkg.com/reqlist/lib/reqlist.css" />
+
+  <script class='remove' src="./common.js"></script>
+  <script class="remove" type="text/javascript">
+  var respecConfig = {
+    // the W3C WG and public mailing list
+    group: "ccg",
+    wgPublicList: "public-credentials",
+
+    // the specification's short name, as in http://www.w3.org/TR/short-name/
+    shortName: "vc-http-api",
+
+    // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
+    specStatus: "CGDRAFT",
+
+    // W3C Candidate Recommendation information
+    //crEnd: "2021-05-04",
+    //implementationReportURI: "https://w3c.github.io/vc-http-api-test-suite/",
+
+    // Editor's Draft URL
+    edDraftURI: "https://w3c-ccg.github.io/vc-http-api/",
+
+    // subtitle for the spec
+    subtitle: "A HTTP API for Verifiable Credentials lifecycle management",
+
+    // if you wish the publication date to be other than today, set this
+    //publishDate:  "2019-11-07",
+
+    // previously published draft, uncomment this and set its
+    // YYYY-MM-DD date and its maturity status
+    //previousPublishDate:  "2021-03-01",
+    //previousMaturity:  "WD",
+
+    // automatically allow term pluralization
+    pluralize: true,
+
+    // extend the bibliography entries
+    localBiblio: ccg.localBiblio,
+    xref: "web-platform",
+    github: {
+      repoURL: "https://github.com/w3c-ccg/vc-http-api/",
+      branch: "main"
+    },
+    includePermalinks: false,
+
+    // Uncomment these to use the respec extension that generates a list of
+    //   normative statements:
+    preProcess: [/*prepare_reqlist*/],
+    postProcess: [/*add_reqlist_button*/, restrictRefs],
+
+    // list of specification editors
+    editors: [],
+
+    // list of specification authors
+    authors: []
+    };
+  </script>
+  <style>
+  pre .highlight {
+    font-weight: bold;
+    color: green;
+  }
+  pre .comment {
+    color: SteelBlue;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+  code a[href] {
+    color: inherit;
+    border-bottom: none;
+  }
+  code a[href]:hover {
+    border-bottom: 1px solid #c63501;
+  }
+  table.column-width-50 td {
+    width: 50%;
+  }
+  </style>
+</head>
+<body data-cite="infra rfc3986">
+  <section id='abstract'>
+
+    <p>
+Verifiable credentials provide a mechanism to express credentials on
+the Web in a way that is cryptographically secure, privacy respecting,
+and machine-verifiable. This specification provides data model and
+HTTP protocols to issue, verify, present, and manage data used in such an
+ecosystem.
+    </p>
+  </section>
+
+  <section id='sotd'>
+    <p>
+This specification is highly experimental and changing rapidly. Implementation
+in non-experimental systems is discouraged unless you are participating in
+the weekly meetings that coordinate activity around this specification.
+    </p>
+
+    <p>
+Comments regarding this document are welcome. Please file issues
+directly on <a href="https://github.com/w3c-ccg/vc-http-api/issues/">GitHub</a>,
+or send them
+to <a href="mailto:public-credentials@w3.org">public-credentials@w3.org</a> (
+<a href="mailto:public-credentials-request@w3.org?subject=subscribe">subscribe</a>,
+<a href="https://lists.w3.org/Archives/Public/public-credentials/">archives</a>).
+    </p>
+
+  </section>
+
+  <section class="informative">
+    <h1>Introduction</h1>
+    <p>
+    </p>
+
+    <section class="informative">
+      <h2>A Simple Example</h2>
+
+      <p>
+      </p>
+
+      <figure id="issue-a-vc">
+        <img style="margin: auto; display: block; width: 75%;"
+          src="diagrams/issue-a-vc.svg" alt="
+An example of Verifiable Credential issuance.
+        " >
+        <figcaption>
+A simple example of issuing a Verifiable Credential.
+        </figcaption>
+      </figure>
+
+    </section>
+
+    <section class="informative">
+      <h2>Design Goals</h2>
+
+      <p>
+      </p>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>
+Goal
+            </th>
+            <th>
+Description
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>
+TBD
+            </td>
+            <td>
+TBD
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="informative">
+      <h2>
+Architecture Overview
+      </h2>
+
+      <p>
+This section provides a basic overview of the major components of this
+specification's architecture.
+      </p>
+
+      <figure id="brief-architecture-overview">
+        <img style="margin: auto; display: block; width: 75%;"
+          src="diagrams/vc-http-api-architecture.svg" alt="
+        " >
+        <figcaption>
+Overview of the VC HTTP API architecture and the relationship of the
+basic components.
+        </figcaption>
+      </figure>
+
+    </section>
+
+    <section id="conformance">
+
+      <p>
+      </p>
+
+     <p>
+A <dfn>conforming VC HTTP API client</dfn> is ...
+     </p>
+
+      <p>
+A <dfn>conforming VC HTTP API server</dfn> is ...
+      </p>
+
+    </section>
+
+  </section>
+
+  <section class="informative">
+    <h2>Terminology</h2>
+
+    <div data-include="terms.html">
+    </div>
+
+  </section>
+
+  <section>
+    <h2>The VC HTTP API</h2>
+    <section>
+      <h3>Authorization</h3>
+      <p>
+      </p>
+    </section>
+
+    <section>
+      <h3>Issuing</h3>
+      <p>
+      </p>
+    </section>
+
+    <section>
+      <h3>Verifying</h3>
+      <p>
+      </p>
+    </section>
+
+    <section>
+      <h3>Presenting</h3>
+      <p>
+      </p>
+    </section>
+
+  </section>
+
+  <section class="appendix">
+    <h2>Privacy Considerations</h2>
+    <p>
+    </p>
+  </section>
+
+  <section class="appendix">
+    <h2>Security Considerations</h2>
+    <p>
+    </p>
+  </section>
+
+  <section class="appendix">
+    <h2>Acknowledgements</h2>
+    <p>
+The Working Group thanks the following individuals for their contributions
+to this specification: <span class="issue">The final list of acknowledgements
+will be compiled at the end of the Candidate Recommendation phase.</span>
+    </p>
+    <p>
+Portions of the work on this specification have been funded by the United States
+Department of Homeland Security's Silicon Valley Innovation Program under
+contracts 70RSAT20T00000010, and 70RSAT20T00000029. The content of this
+specification does not necessarily reflect the position or the policy of the
+U.S. Government and no official endorsement should be inferred.
+    </p>
+
+    <p>
+Development of this specification has
+also been supported by the <a href="https://w3c-ccg.github.io/">W3C Credentials
+Community Group</a>, chaired by Kim Hamilton Duffy, Heather Vescent,
+and Wayne Chang.
+    </p>
+
+  </section>
+
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -12,9 +12,8 @@ included whenever they appear in this specification.
 A globally unique persistent identifier that does not require a centralized
 registration authority and is often generated and/or registered
 cryptographically. The generic format of a DID is defined in <a
-href="https://www.w3.org/TR/did-core/#did-syntax">DID Core: Syntax</a>. A
-specific <a>DID scheme</a> is defined in a <a>DID method</a> specification.
-Many—but not all—DID methods make use of <a>distributed ledger technology</a>
+href="https://www.w3.org/TR/did-core/#did-syntax">DID Core: Syntax</a>.
+Many—but not all—DID methods make use of distributed ledger technology
 (DLT) or some other form of decentralized network.
   </dd>
 

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,45 @@
+<p>
+This section defines the terms used in this specification and throughout
+<a>decentralized identifier</a> infrastructure. A link to these terms is
+included whenever they appear in this specification.
+</p>
+
+<dl class="termlist">
+
+  <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn> (DID)</dt>
+
+  <dd>
+A globally unique persistent identifier that does not require a centralized
+registration authority and is often generated and/or registered
+cryptographically. The generic format of a DID is defined in <a
+href="https://www.w3.org/TR/did-core/#did-syntax">DID Core: Syntax</a>. A
+specific <a>DID scheme</a> is defined in a <a>DID method</a> specification.
+Many—but not all—DID methods make use of <a>distributed ledger technology</a>
+(DLT) or some other form of decentralized network.
+  </dd>
+
+  <dt><dfn data-lt="URI|URIs">Uniform Resource Identifier</dfn> (URI)</dt>
+
+  <dd>
+The standard identifier format for all resources on the World Wide Web as
+defined by [[RFC3986]]. A <a>DID</a> is a type of URI scheme.
+  </dd>
+
+  <dt><dfn data-lt="verifiable credentials">verifiable credential</dfn></dt>
+
+  <dd>
+A standard data model and representation format for cryptographically-verifiable
+digital credentials as defined by the W3C Verifiable Credentials specification
+[[VC-DATA-MODEL]].
+  </dd>
+
+  <dt><dfn data-lt="UUID|UUIDs">Universally Unique Identifier</dfn> (UUID)</dt>
+
+  <dd>
+A type of globally unique identifier defined by [[RFC4122]]. UUIDs are similar
+to DIDs in that they do not require a centralized registration authority. UUIDs
+differ from DIDs in that they are not resolvable or
+cryptographically-verifiable.
+  </dd>
+
+</dl>


### PR DESCRIPTION
This implements a decision made on a previous call:

https://w3c-ccg.github.io/meetings/2021-05-06-vchttpapi/#resolution-1

RESOLUTION: Create 1 ReSpec specification based on the OAS files, in addition to separating the existing OAS files into modular components.