### PR TITLE
Add proof type issue/present option

### DIFF
--- a/docs/components/IssueCredentialOptions.yml
+++ b/docs/components/IssueCredentialOptions.yml
@@ -17,6 +17,9 @@ components:
       additionalProperties: false
       description: Options for specifying how the LinkedDataProof is created.
       properties:
+        type:
+          type: string
+          description: The type of the proof. Default is an appropriate proof type corresponding to the verification method.
         verificationMethod:
           type: string
           description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
@@ -41,6 +44,7 @@ components:
               description: The type of credential status to issue the credential with
       example:
         {
+          "type": "Ed25519Signature2018",
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
           "proofPurpose": "assertionMethod",
           "created": "2020-04-02T18:48:36Z",

--- a/docs/components/PresentCredentialOptions.yml
+++ b/docs/components/PresentCredentialOptions.yml
@@ -17,6 +17,9 @@ components:
       additionalProperties: false
       description: Options for specifying how the LinkedDataProof is created.
       properties:
+        type:
+          type: string
+          description: The type of the proof. Default is an appropriate proof type corresponding to the verification method.
         verificationMethod:
           type: string
           description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
@@ -34,6 +37,7 @@ components:
           description: The intended domain of validity for the proof. For example website.example
       example:
         {
+          "type": "Ed25519Signature2018",
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
           "proofPurpose": "assertionMethod",
           "created": "2020-04-02T18:48:36Z",


### PR DESCRIPTION
Signature suite [Ethereum EIP712 Signature 2021](https://uport-project.github.io/ethereum-eip712-signature-2021-spec/) (proposed work item: https://github.com/w3c-ccg/community/issues/194) does not define a new verification method but only a signing method (proof type), and is meant to be used with existing verification methods `EcdsaSecp256k1VerificationKey2019` or `EcdsaSecp256k1RecoveryMethod2020`. For proof creation with `vc-http-api`, the `verificationMethod` option of the issue/present credential options is then no longer sufficient to identify the type of proof to create, since there is not a one-to-one correspondance of verification method type to proof type. This PR adds a type option for use in situations such as this where there is more than one type of proof that could be issued.

Edit: relevant issue #47.
This also could be useful if one wants to choose between using e.g. `Ed25519Signature2018` or `Ed25519Signature2020` when the issuer/holder is using `did:key`.