### PR TITLE
Support JWT

### DIFF
--- a/docs/components/VerifiableCredential.yml
+++ b/docs/components/VerifiableCredential.yml
@@ -13,40 +13,45 @@ paths:
 components:
   schemas:
     VerifiableCredential:
-      type: object
-      description: A JSON-LD Verifiable Credential with a proof.
-      allOf:
-        - $ref: "./Credential.yml#/components/schemas/Credential"
+      oneOf:
+        - type: string
+          description: A JWT Verifiable Credential
+          example:
+            eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2lWcHdBMjQxZ3VxdEtXQWtvaEhwY0FyeTdTOTRRUWI2dWtXM0djQ3N1Z2JLI3o2TWtpVnB3QTI0MWd1cXRLV0Frb2hIcGNBcnk3Uzk0UVFiNnVrVzNHY0NzdWdiSyJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZToxMjMiLCJuYmYiOjE2MjQ2MzU0MTYsImp0aSI6Imh0dHA6Ly9leGFtcGxlLmdvdi9jcmVkZW50aWFscy8zNzMyIiwic3ViIjoiZGlkOmV4YW1wbGU6MTIzIiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJ0eXBlIjoiQmFjaGVsb3JEZWdyZWUifX0sImlzc3VhbmNlRGF0ZSI6IjIwMjEtMDYtMjVUMTU6MzY6NTZaIn19.FnYoavlqTQSbaVZ15TNo3mzlo9nbKtzzZkSHjwngD6yR-Z-9iXXSZ4ZZu17bv90Z279RUGzY0M89-fIHrmP5DA
         - type: object
-          properties:
-            proof:
-              $ref: "./LinkedDataProof.yml#/components/schemas/LinkedDataProof"
-      example:
-        {
-          "@context":
-            [
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1",
-            ],
-          "id": "http://example.gov/credentials/3732",
-          "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": "did:example:123",
-          "issuanceDate": "2020-03-16T22:37:26.544Z",
-          "credentialSubject":
+          description: A JSON-LD Verifiable Credential with a proof.
+          allOf:
+            - $ref: "./Credential.yml#/components/schemas/Credential"
+            - type: object
+              properties:
+                proof:
+                  $ref: "./LinkedDataProof.yml#/components/schemas/LinkedDataProof"
+          example:
             {
-              "id": "did:example:123",
-              "degree":
+              "@context":
+                [
+                    "https://www.w3.org/2018/credentials/v1",
+                    "https://www.w3.org/2018/credentials/examples/v1",
+                ],
+              "id": "http://example.gov/credentials/3732",
+              "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+              "issuer": "did:example:123",
+              "issuanceDate": "2020-03-16T22:37:26.544Z",
+              "credentialSubject":
                 {
-                  "type": "BachelorDegree",
-                  "name": "Bachelor of Science and Arts",
+                  "id": "did:example:123",
+                  "degree":
+                    {
+                      "type": "BachelorDegree",
+                      "name": "Bachelor of Science and Arts",
+                    },
                 },
-            },
-          "proof":
-            {
-              "type": "Ed25519Signature2018",
-              "created": "2020-04-02T18:28:08Z",
-              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-              "proofPurpose": "assertionMethod",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
-            },
-        }
+              "proof":
+                {
+                  "type": "Ed25519Signature2018",
+                  "created": "2020-04-02T18:28:08Z",
+                  "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+                  "proofPurpose": "assertionMethod",
+                  "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
+                },
+            }

--- a/docs/components/VerifiablePresentation.yml
+++ b/docs/components/VerifiablePresentation.yml
@@ -13,58 +13,63 @@ paths:
 components:
   schemas:
     VerifiablePresentation:
-      type: object
-      description: A JSON-LD Verifiable Presentation with a proof.
-      allOf:
-        - $ref: "./Presentation.yml#/components/schemas/Presentation"
+      oneOf:
+        - type: string
+          description: A JWT Verifiable Presentation
+          example:
+            eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2lWcHdBMjQxZ3VxdEtXQWtvaEhwY0FyeTdTOTRRUWI2dWtXM0djQ3N1Z2JLI3o2TWtpVnB3QTI0MWd1cXRLV0Frb2hIcGNBcnk3Uzk0UVFiNnVrVzNHY0NzdWdiSyJ9.eyJqdGkiOiJodHRwOi8vZXhhbXBsZS5nb3YvY3JlZGVudGlhbHMvMzczMiIsInZwIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjEiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl0sInByb29mIjp7InR5cGUiOiJFZDI1NTE5U2lnbmF0dXJlMjAxOCIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDpleGFtcGxlOjEyMyN6Nk1rc0hoN3FIV3Z5YkxnNVFUUFBkRzJEZ0VqamR1QkRBclY5RUY5bVJpUnpNQk4iLCJjcmVhdGVkIjoiMjAyMC0wNC0wMlQxODoyODowOFoiLCJqd3MiOiJleUpoYkdjaU9pSkZaRVJUUVNJc0ltSTJOQ0k2Wm1Gc2MyVXNJbU55YVhRaU9sc2lZalkwSWwxOS4uWXRxakVZbkZFTlQ3Zk5XLUNPRDBIQUFDeGV1UXhQS0FtcDRuSWw4allBdV9fNklIMkZwU3h2ODF3LWw1UHZFMW9nNTB0Uzl0SDhXeVhNbFh5bzQ1Q0EifSwiaXNzdWVyIjoiZGlkOmV4YW1wbGU6MTIzIiwiaXNzdWFuY2VEYXRlIjoiMjAyMC0wMy0xNlQyMjozNzoyNi41NDRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiZGVncmVlIjp7Im5hbWUiOiJCYWNoZWxvciBvZiBTY2llbmNlIGFuZCBBcnRzIiwidHlwZSI6IkJhY2hlbG9yRGVncmVlIn0sImlkIjoiZGlkOmV4YW1wbGU6MTIzIn19fQ.fYcLJgGu2q4xLwUp40D8zQ45bOSu5ctX1qzn7aaHU77OTqDsMrAyNirhmFc00-1967Xnu9OUCiqJLOjHATSQAg
         - type: object
-          properties:
-            proof:
-              $ref: "./LinkedDataProof.yml#/components/schemas/LinkedDataProof"
-      example:
-        {
-          "@context":
-            [
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1",
-            ],
-          "holder": "did:example:123",
-          "type": "VerifiablePresentation",
-          "verifiableCredential":
-            [
-                "@context":
-                  [
-                      "https://www.w3.org/2018/credentials/v1",
-                      "https://www.w3.org/2018/credentials/examples/v1",
-                  ],
-                "id": "http://example.gov/credentials/3732",
-                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-                "issuer": "did:example:123",
-                "issuanceDate": "2020-03-16T22:37:26.544Z",
-                "credentialSubject":
-                  {
-                    "id": "did:example:123",
-                    "degree":
-                      {
-                        "type": "BachelorDegree",
-                        "name": "Bachelor of Science and Arts",
-                      },
-                  },
-                "proof":
-                  {
-                    "type": "Ed25519Signature2018",
-                    "created": "2020-04-02T18:28:08Z",
-                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-                    "proofPurpose": "assertionMethod",
-                    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
-                  },
-            ],
-          "proof":
+          description: A JSON-LD Verifiable Presentation with a proof.
+          allOf:
+            - $ref: "./Presentation.yml#/components/schemas/Presentation"
+            - type: object
+              properties:
+                proof:
+                  $ref: "./LinkedDataProof.yml#/components/schemas/LinkedDataProof"
+          example:
             {
-              "type": "Ed25519Signature2018",
-              "created": "2020-04-02T18:28:08Z",
-              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-              "proofPurpose": "assertionMethod",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
-            },
-        }
+              "@context":
+                [
+                    "https://www.w3.org/2018/credentials/v1",
+                    "https://www.w3.org/2018/credentials/examples/v1",
+                ],
+              "holder": "did:example:123",
+              "type": "VerifiablePresentation",
+              "verifiableCredential":
+                [
+                    "@context":
+                      [
+                          "https://www.w3.org/2018/credentials/v1",
+                          "https://www.w3.org/2018/credentials/examples/v1",
+                      ],
+                    "id": "http://example.gov/credentials/3732",
+                    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                    "issuer": "did:example:123",
+                    "issuanceDate": "2020-03-16T22:37:26.544Z",
+                    "credentialSubject":
+                      {
+                        "id": "did:example:123",
+                        "degree":
+                          {
+                            "type": "BachelorDegree",
+                            "name": "Bachelor of Science and Arts",
+                          },
+                      },
+                    "proof":
+                      {
+                        "type": "Ed25519Signature2018",
+                        "created": "2020-04-02T18:28:08Z",
+                        "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+                        "proofPurpose": "assertionMethod",
+                        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
+                      },
+                ],
+              "proof":
+                {
+                  "type": "Ed25519Signature2018",
+                  "created": "2020-04-02T18:28:08Z",
+                  "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+                  "proofPurpose": "assertionMethod",
+                  "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
+                },
+            }

--- a/docs/components/VerifyOptions.yml
+++ b/docs/components/VerifyOptions.yml
@@ -17,6 +17,9 @@ components:
       additionalProperties: false
       description: Options for specifying how the LinkedDataProof is created.
       properties:
+        type:
+          type: string
+          description: The type of the proof. Default is to allow any known proof type that verifies against the verification method.
         verificationMethod:
           type: string
           description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.


### PR DESCRIPTION
Add support for [JWT](https://www.w3.org/TR/vc-data-model/#json-web-token) [proof format](https://www.w3.org/TR/vc-data-model/#proof-formats) in the API.

The `VerifiableCredential` and `VerifiablePresentation` types are changed to allow a `string` value, using `oneOf`. (Changes in the  associated yaml files in the `object` section are indentation only).

An option for issuing or presenting a credential ~~is~~ could be (re-)added, `proofFormat`, with possible values "jwt" or "ldp". ~~Would there be more idiomatic existing terms to use here?~~

This API change assumes that the existing routes and options handling LDPs can be used with JWTs. ~~Should it be documented how that should work? e.g. the `domain` option could correspond to the `aud` claim.~~ How this works, in addition to what VC Data Model specifies, could be determined by the `type` option in a issue/present/verify call.

~~Should there be an issue/present option for "additional JWT claims" that the caller may want to add outside the VC/VP?~~

Related issues: #42, #207