### PR TITLE
Add section on OAuth 2.0 and bearer tokens.

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@ or legacy authorization technologies.
         <p>
 If Open Authorization is utilized for authorization, version 2.0 of the
 protocol (OAuth 2.0) [[RFC6749]] MUST be used. The access tokens utilized by
-clients MAY be OAuth 2.0 Bearer Tokens [[RFC6750]]  or any other valid OAuth 2.0
+clients MAY be OAuth 2.0 Bearer Tokens [[RFC6750]] or any other valid OAuth 2.0
 token type.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -310,6 +310,16 @@ technologies can be used. Implementers are cautioned against using non-standard
 or legacy authorization technologies.
       </p>
 
+      <section>
+        <h4>Open Authorization (OAuth)</h4>
+        <p>
+If Open Authorization is utilized for authorization, version 2.0 of the
+protocol (OAuth 2.0) [[RFC6749]] MUST be used. The access tokens utilized by
+clients MAY be OAuth 2.0 Bearer Tokens [[RFC6750]]  or any other valid OAuth 2.0
+token type.
+        </p>
+      </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -311,12 +311,12 @@ or legacy authorization technologies.
       </p>
 
       <section>
-        <h4>Open Authorization (OAuth)</h4>
+        <h4>OAuth 2.0</h4>
         <p>
-If Open Authorization is utilized for authorization, version 2.0 of the
-protocol (OAuth 2.0) [[RFC6749]] MUST be used. The access tokens utilized by
-clients MAY be OAuth 2.0 Bearer Tokens [[RFC6750]] or any other valid OAuth 2.0
-token type.
+If the OAuth 2.0 Authorization Framework [[RFC6749]] is utilized for authorization,
+the access tokens utilized by clients MAY be OAuth 2.0 Bearer Tokens [[RFC6750]]
+or any other valid OAuth 2.0 token type. Any valid OAuth 2.0 grant type MAY be used
+to request the access tokens.
         </p>
       </section>
 


### PR DESCRIPTION
This PR specifies that OAuth 2.0 and OAuth 2.0 bearer tokens can be used as an authorization protocol and access token format.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-http-api/pull/231.html" title="Last updated on Sep 26, 2021, 12:03 AM UTC (901d266)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-http-api/231/ed6a27e...901d266.html" title="Last updated on Sep 26, 2021, 12:03 AM UTC (901d266)">Diff</a>