### PR TITLE
Add ReSpec auto-generator from OAS files.

### DIFF
--- a/common.js
+++ b/common.js
@@ -314,3 +314,69 @@ function unComment(doc, content) {
     .replace(/-\s*- >/g, '-->')
     .replace(/-\s*-\s*&gt;/g, '--&gt;');
 }
+
+/********************* OAS Experiment *************************/
+function getEndpoint({apis, path}) {
+  let endpoint = {
+    post: {
+      summary: 'Error: API Endpoint not defined - ' + path
+    }
+  };
+
+  for(const api of apis) {
+    if(api.paths[path] !== undefined) {
+      endpoint = api.paths[path];
+    }
+  }
+
+  return endpoint;
+}
+
+function buildApiSummaryTables({config, document, apis}) {
+  const apiTables = document.querySelectorAll("table.api-summary-table");
+
+  // process every table
+  for(const table of apiTables) {
+    // set up the API summary table headers
+    const tableHeader = document.createElement('tr');
+    tableHeader.innerHTML = '<th>Endpoint</th><th>Description</th>';
+    table.appendChild(tableHeader);
+
+    // summarize each API endpoint
+    for(const path of table.dataset.apiPath.split(/\s+/)) {
+      if(path.trim().length > 0) {
+        const endpoint = getEndpoint({apis, path});
+        console.log("ENDPOINT", endpoint);
+        for(const verb in endpoint) {
+          const {summary} = endpoint[verb];
+          const tableRow = document.createElement('tr');
+          tableRow.innerHTML =
+            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${summary}</td>`;
+          table.appendChild(tableRow);
+        }
+      }
+    }
+    //const paths = (table.dataset.apiPath).split(' ');
+    //console.log("PATHS", paths);
+  }
+}
+
+async function injectOas(config, document) {
+  try {
+    let issuerApi = await SwaggerParser.validate('issuer.yml');
+    console.log('API name: %s, Version: %s',
+      issuerApi.info.title, issuerApi.info.version);
+    let verifierApi = await SwaggerParser.validate('verifier.yml');
+    console.log('API name: %s, Version: %s',
+      verifierApi.info.title, verifierApi.info.version);
+    let holderApi = await SwaggerParser.validate('holder.yml');
+    console.log('API name: %s, Version: %s',
+      holderApi.info.title, holderApi.info.version);
+    const apis = [issuerApi, verifierApi, holderApi];
+
+    buildApiSummaryTables({config, document, apis});
+  }
+  catch(err) {
+    console.error(err);
+  }
+}

--- a/common.js
+++ b/common.js
@@ -366,7 +366,6 @@ function buildEndpointDetails({config, document, apis}) {
     // detail each API endpoint
     const [verb, path] = section.dataset.apiEndpoint.split(/\s+/);
     const endpoint = getEndpoint({apis, path})[verb];
-    console.log("buildEndpointDetails", endpoint);
 
     // summary for endpoint
     const summary = document.createElement('p');

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -37,7 +37,7 @@ components:
           type: array
           description: The Verifiable Credentials
           items:
-            $ref: "#/components/schemas/VerifiableCredential"
+            $ref: "./VerifiableCredential.yml#/components/schemas/VerifiableCredential"
       example:
         {
           "@context":

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     src="https://unpkg.com/browse/jquery/dist/jquery.min.js"></script>
   <script class="remove"
     src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+  <script class="remove"
+    src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-oas@0.0.1/dist/main.js"></script>
   <script class="removeOnSave"
     src="https://unpkg.com/reqlist/lib/reqlist.js"></script>
   <link class="removeOnSave" rel="stylesheet" type="text/css"
@@ -65,7 +67,7 @@
     // Uncomment these to use the respec extension that generates a list of
     //   normative statements:
     preProcess: [/*prepare_reqlist*/],
-    postProcess: [/*add_reqlist_button*/, restrictRefs],
+    postProcess: [/*add_reqlist_button*/, injectOas, restrictRefs],
 
     // list of specification editors
     editors: [{
@@ -315,19 +317,34 @@ or legacy authorization technologies.
     <section>
       <h3>Issuing</h3>
       <p>
+The following APIs are defined for issuing a Verifiable Credential:
       </p>
+
+      <table class="simple api-summary-table"
+        data-api-path="/credentials/issue /credentials/status"></table>
     </section>
 
     <section>
       <h3>Verifying</h3>
       <p>
+The following APIs are defined for verifyig a Verifiable Credential:
       </p>
+
+      <table class="simple api-summary-table"
+        data-api-path="/credentials/verify /presentations/verify"></table>
     </section>
 
     <section>
       <h3>Presenting</h3>
       <p>
+The following APIs are defined for presenting a Verifiable Credential:
       </p>
+
+      <table class="simple api-summary-table"
+        data-api-path="
+          /credentials/derive /presentations/prove
+          /presentations/available /presentations/submissions"
+        ></table>
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -322,6 +322,15 @@ The following APIs are defined for issuing a Verifiable Credential:
 
       <table class="simple api-summary-table"
         data-api-path="/credentials/issue /credentials/status"></table>
+
+      <section>
+        <h4>Issue</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /credentials/issue"></div>
+      </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -324,13 +324,23 @@ The following APIs are defined for issuing a Verifiable Credential:
         data-api-path="/credentials/issue /credentials/status"></table>
 
       <section>
-        <h4>Issue</h4>
+        <h4>Issue Credential</h4>
         <p>
         </p>
 
         <div class="api-detail"
           data-api-endpoint="post /credentials/issue"></div>
       </section>
+
+      <section>
+        <h4>Update Status</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /credentials/status"></div>
+      </section>
+
     </section>
 
     <section>
@@ -341,6 +351,25 @@ The following APIs are defined for verifyig a Verifiable Credential:
 
       <table class="simple api-summary-table"
         data-api-path="/credentials/verify /presentations/verify"></table>
+
+      <section>
+        <h4>Verify Credential</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /credentials/verify"></div>
+      </section>
+
+      <section>
+        <h4>Verify Presentation</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /presentations/verify"></div>
+      </section>
+
     </section>
 
     <section>
@@ -354,6 +383,43 @@ The following APIs are defined for presenting a Verifiable Credential:
           /credentials/derive /presentations/prove
           /presentations/available /presentations/submissions"
         ></table>
+
+      <section>
+        <h4>Derive Credential</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /credentials/derive"></div>
+      </section>
+
+      <section>
+        <h4>Prove Presentation</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /presentations/prove"></div>
+      </section>
+
+      <section>
+        <h4>Presentation Availability</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /presentations/available"></div>
+      </section>
+
+      <section>
+        <h4>Submit Presentation</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /presentations/submissions"></div>
+      </section>
+
     </section>
 
   </section>


### PR DESCRIPTION
This PR adds an ability to ReSpec to generate sections of the specification directly from the OAS files. This ensures that the root of truth continues to be the OAS files, but that those are also translated into human-readable normative ReSpec descriptions.

This is the first iteration of this experimental feature. There is still a lot of formatting that needs to be done with the JSON Schema sections to ReSpec text, but that is fairly straight-forward to do and will just take a bit of time to get formatted into the shape that we want.

You can preview what all of this looks like here: https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-http-api/pull/233.html#the-vc-http-api


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-http-api/pull/233.html" title="Last updated on Sep 26, 2021, 12:20 AM UTC (597657d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-http-api/233/ed6a27e...597657d.html" title="Last updated on Sep 26, 2021, 12:20 AM UTC (597657d)">Diff</a>